### PR TITLE
Upstream enigmampc/cosmwasm 7429ac1

### DIFF
--- a/cosmwasm/CHANGELOG.md
+++ b/cosmwasm/CHANGELOG.md
@@ -24,6 +24,10 @@
   can still make use of the field.
 - Rename `MockQuerier::with_staking` to `MockQuerier::update_staking` to match
   `::update_balance`.
+- The obsolete `StdError::NullPointer` and `null_pointer` were removed.
+- Error creator functions are now in type itself, e.g.
+  `StdError::invalid_base64` instead of `invalid_base64`. The free functions are
+  deprecated and will be removed before 1.0.
 
 **cosmwasm-storage**
 
@@ -77,6 +81,7 @@
   in `CommunicationError::InvalidUtf8`, which is not reported back to the
   contract. A standard library should ensure this never happens by correctly
   encoding string input values.
+- Merge trait `ReadonlyStorage` into `Storage`.
 
 ## 0.8.1 (2020-06-08)
 

--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli 0.21.0",
 ]
@@ -213,7 +213,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-sgx-vm"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.12.2",
  "cosmwasm-std",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.11.0",
  "cosmwasm-schema",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -888,9 +888,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1030,9 +1030,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cosmwasm/MIGRATING.md
+++ b/cosmwasm/MIGRATING.md
@@ -4,6 +4,48 @@ This guide explains what is needed to upgrade contracts when migrating over
 major releases of `cosmwasm`. Note that you can also view the
 [complete CHANGELOG](./CHANGELOG.md) to understand the differences.
 
+## 0.8 -> 0.9
+
+`dependencies`/`dev-dependencies` in `Cargo.toml`:
+
+- Replace `cosmwasm-schema = "0.8"` with `cosmwasm-schema = "0.9"`
+- Replace `cosmwasm-std = "0.8"` with `cosmwasm-std = "0.9"`
+- Replace `cosmwasm-storage = "0.8"` with `cosmwasm-storage = "0.9"`
+- Replace `cosmwasm-vm = "0.8"` with `cosmwasm-vm = "0.9"`
+
+`lib.rs`:
+
+- The C export boilerplate can now be reduced to the following code (see e.g. in
+  [hackatom/src/lib.rs](https://github.com/CosmWasm/cosmwasm/blob/0a5b3e8121/contracts/hackatom/src/lib.rs)):
+
+  ```rust
+  mod contract; // contains init, handle, query
+  // maybe additional modules here
+
+  #[cfg(target_arch = "wasm32")]
+  cosmwasm_std::create_entry_points!(contract);
+  ```
+
+Contract code and uni tests:
+
+- `cosmwasm_storage::get_with_prefix`, `cosmwasm_storage::set_with_prefix`,
+  `cosmwasm_storage::RepLog::commit`, `cosmwasm_std::ReadonlyStorage::get`,
+  `cosmwasm_std::ReadonlyStorage::range`, `cosmwasm_std::Storage::set` and
+  `cosmwasm_std::Storage::remove` now return the value directly that was wrapped
+  in a result before.
+- Error creator functions are now in type itself, e.g.
+  `StdError::invalid_base64` instead of `invalid_base64`. The free functions are
+  deprecated and will be removed before 1.0.
+- Remove `InitResponse.data` in `init`. Before 0.9 this was not stored to chain
+  but ignored.
+- Use `cosmwasm_storage::transactional` instead of the removed
+  `cosmwasm_storage::transactional_deps`.
+
+Integration tests:
+
+- Replace `cosmwasm_vm::ReadonlyStorage` with `cosmwasm_vm::Storage`, which now
+  contains all backend storage methods.
+
 ## 0.7.2 -> 0.8
 
 ### Update wasm code

--- a/cosmwasm/README.md
+++ b/cosmwasm/README.md
@@ -288,7 +288,7 @@ nightly toolchain installed as well.
 
 ```sh
 cargo fmt \
-  && (cd packages/std && cargo wasm-debug --features iterator && cargo test --features iterator && cargo clippy --features iterator -- -D warnings) \
+  && (cd packages/std && cargo wasm-debug --features iterator && cargo test --features iterator && cargo clippy --features iterator -- -D warnings && cargo schema) \
   && (cd packages/storage && cargo build && cargo test --features iterator && cargo clippy --features iterator -- -D warnings) \
   && (cd packages/schema && cargo build && cargo test && cargo clippy -- -D warnings) \
   && (cd packages/vm && cargo +nightly build --features iterator && cargo +nightly test --features iterator && cargo +nightly clippy --features iterator -- -D warnings)

--- a/cosmwasm/contracts/burner/Cargo.lock
+++ b/cosmwasm/contracts/burner/Cargo.lock
@@ -2,12 +2,18 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli 0.21.0",
 ]
+
+[[package]]
+name = "adler32"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
 name = "ansi_term"
@@ -49,13 +55,14 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
+checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -209,7 +216,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -217,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-sgx-vm"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.12.2",
  "cosmwasm-std",
@@ -242,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.11.0",
  "schemars",
@@ -339,12 +346,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6bffe714b6bb07e42f201352c34f51fefd355ace793f9e638ebd52d23f98d2"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -505,9 +513,9 @@ checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
+checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
 ]
@@ -530,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "lazy_static"
@@ -590,6 +598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
 name = "nix"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "opaque-debug"
@@ -751,10 +768,11 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
 dependencies = [
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -762,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
+checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
@@ -855,9 +873,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
@@ -883,18 +901,18 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf487fbf5c6239d7ea2ff8b10cb6b811cd4b5080d1c2aeed1dec18753c06e10"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -914,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
  "itoa",
  "ryu",
@@ -997,9 +1015,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1037,18 +1055,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cosmwasm/contracts/burner/src/contract.rs
+++ b/cosmwasm/contracts/burner/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    generic_err, log, Api, BankMsg, Binary, Env, Extern, HandleResponse, InitResponse,
-    MigrateResponse, Order, Querier, StdResult, Storage,
+    log, Api, BankMsg, Binary, Env, Extern, HandleResponse, InitResponse, MigrateResponse, Order,
+    Querier, StdError, StdResult, Storage,
 };
 
 use crate::msg::{HandleMsg, InitMsg, MigrateMsg, QueryMsg};
@@ -10,7 +10,9 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
     _env: Env,
     _msg: InitMsg,
 ) -> StdResult<InitResponse> {
-    Err(generic_err("You can only use this contract for migrations"))
+    Err(StdError::generic_err(
+        "You can only use this contract for migrations",
+    ))
 }
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(
@@ -18,7 +20,9 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
     _env: Env,
     _msg: HandleMsg,
 ) -> StdResult<HandleResponse> {
-    Err(generic_err("You can only use this contract for migrations"))
+    Err(StdError::generic_err(
+        "You can only use this contract for migrations",
+    ))
 }
 
 pub fn migrate<S: Storage, A: Api, Q: Querier>(
@@ -59,7 +63,9 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
     _deps: &Extern<S, A, Q>,
     _msg: QueryMsg,
 ) -> StdResult<Binary> {
-    Err(generic_err("You can only use this contract for migrations"))
+    Err(StdError::generic_err(
+        "You can only use this contract for migrations",
+    ))
 }
 
 #[cfg(test)]

--- a/cosmwasm/contracts/burner/src/lib.rs
+++ b/cosmwasm/contracts/burner/src/lib.rs
@@ -2,47 +2,4 @@ pub mod contract;
 pub mod msg;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_migrate, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_migrate(
-            &contract::migrate::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::create_entry_points_with_migration!(contract);

--- a/cosmwasm/contracts/burner/tests/integration.rs
+++ b/cosmwasm/contracts/burner/tests/integration.rs
@@ -22,7 +22,7 @@ use cosmwasm_vm::testing::{init, migrate, mock_env, mock_instance, MOCK_CONTRACT
 use cosmwasm_vm::StorageIterator;
 
 use burner::msg::{InitMsg, MigrateMsg};
-use cosmwasm_vm::{ReadonlyStorage, Storage};
+use cosmwasm_vm::Storage;
 
 // This line will test the output of cargo wasm
 static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/burner.wasm");

--- a/cosmwasm/contracts/hackatom/Cargo.lock
+++ b/cosmwasm/contracts/hackatom/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli 0.21.0",
 ]
@@ -204,7 +204,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-sgx-vm"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.12.2",
  "cosmwasm-std",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.11.0",
  "schemars",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -509,7 +509,7 @@ checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "hackatom"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-sgx-vm",
@@ -881,9 +881,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1023,9 +1023,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cosmwasm/contracts/hackatom/Cargo.toml
+++ b/cosmwasm/contracts/hackatom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hackatom"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 publish = false

--- a/cosmwasm/contracts/hackatom/src/lib.rs
+++ b/cosmwasm/contracts/hackatom/src/lib.rs
@@ -1,47 +1,4 @@
 pub mod contract;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_migrate, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_migrate(
-            &contract::migrate::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::create_entry_points_with_migration!(contract);

--- a/cosmwasm/contracts/hackatom/tests/integration.rs
+++ b/cosmwasm/contracts/hackatom/tests/integration.rs
@@ -27,7 +27,7 @@ use cosmwasm_vm::{
         handle, init, migrate, mock_env, mock_instance, mock_instance_with_balances, query,
         test_io, MOCK_CONTRACT_ADDR,
     },
-    Api, ReadonlyStorage,
+    Api, Storage,
 };
 
 use hackatom::contract::{HandleMsg, InitMsg, MigrateMsg, QueryMsg, State, CONFIG_KEY};

--- a/cosmwasm/contracts/queue/Cargo.lock
+++ b/cosmwasm/contracts/queue/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli 0.21.0",
 ]
@@ -204,7 +204,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-sgx-vm"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.12.2",
  "cosmwasm-std",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.11.0",
  "schemars",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "queue"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-sgx-vm",
@@ -872,9 +872,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
@@ -909,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1014,9 +1014,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cosmwasm/contracts/queue/Cargo.toml
+++ b/cosmwasm/contracts/queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "queue"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 publish = false

--- a/cosmwasm/contracts/queue/src/lib.rs
+++ b/cosmwasm/contracts/queue/src/lib.rs
@@ -1,38 +1,4 @@
 pub mod contract;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::create_entry_points!(contract);

--- a/cosmwasm/contracts/reflect/Cargo.lock
+++ b/cosmwasm/contracts/reflect/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli 0.21.0",
 ]
@@ -204,7 +204,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-sgx-vm"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.12.2",
  "cosmwasm-std",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.11.0",
  "schemars",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -795,7 +795,7 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "reflect"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-sgx-vm",
@@ -1023,9 +1023,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cosmwasm/contracts/reflect/Cargo.toml
+++ b/cosmwasm/contracts/reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflect"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 publish = false
 edition = "2018"

--- a/cosmwasm/contracts/reflect/src/contract.rs
+++ b/cosmwasm/contracts/reflect/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    generic_err, log, to_binary, unauthorized, Api, Binary, CosmosMsg, Env, Extern, HandleResponse,
-    HumanAddr, InitResponse, Querier, StdResult, Storage,
+    log, to_binary, Api, Binary, CosmosMsg, Env, Extern, HandleResponse, HumanAddr, InitResponse,
+    Querier, StdError, StdResult, Storage,
 };
 
 use crate::msg::{
@@ -40,10 +40,10 @@ pub fn try_reflect<S: Storage, A: Api, Q: Querier>(
 ) -> StdResult<HandleResponse<CustomMsg>> {
     let state = config(&mut deps.storage).load()?;
     if env.message.sender != state.owner {
-        return Err(unauthorized());
+        return Err(StdError::unauthorized());
     }
     if msgs.is_empty() {
-        return Err(generic_err("Must reflect at least one message"));
+        return Err(StdError::generic_err("Must reflect at least one message"));
     }
     let res = HandleResponse {
         messages: msgs,
@@ -61,7 +61,7 @@ pub fn try_change_owner<S: Storage, A: Api, Q: Querier>(
     let api = deps.api;
     config(&mut deps.storage).update(|mut state| {
         if env.message.sender != state.owner {
-            return Err(unauthorized());
+            return Err(StdError::unauthorized());
         }
         state.owner = api.canonical_address(&owner)?;
         Ok(state)

--- a/cosmwasm/contracts/reflect/src/lib.rs
+++ b/cosmwasm/contracts/reflect/src/lib.rs
@@ -6,38 +6,4 @@ pub mod state;
 pub mod testing;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::create_entry_points!(contract);

--- a/cosmwasm/contracts/staking/Cargo.lock
+++ b/cosmwasm/contracts/staking/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli 0.21.0",
 ]
@@ -204,7 +204,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-sgx-vm"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.12.2",
  "cosmwasm-std",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.11.0",
  "schemars",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -869,9 +869,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -999,7 +999,7 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "staking"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-sgx-vm",
@@ -1024,9 +1024,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cosmwasm/contracts/staking/Cargo.toml
+++ b/cosmwasm/contracts/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staking"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 

--- a/cosmwasm/contracts/staking/src/lib.rs
+++ b/cosmwasm/contracts/staking/src/lib.rs
@@ -3,38 +3,4 @@ pub mod msg;
 pub mod state;
 
 #[cfg(target_arch = "wasm32")]
-mod wasm {
-    use super::contract;
-    use cosmwasm_std::{
-        do_handle, do_init, do_query, ExternalApi, ExternalQuerier, ExternalStorage,
-    };
-
-    #[no_mangle]
-    extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_init(
-            &contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
-        do_handle(
-            &contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            env_ptr,
-            msg_ptr,
-        )
-    }
-
-    #[no_mangle]
-    extern "C" fn query(msg_ptr: u32) -> u32 {
-        do_query(
-            &contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
-            msg_ptr,
-        )
-    }
-
-    // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
-    // automatically because we `use cosmwasm_std`.
-}
+cosmwasm_std::create_entry_points!(contract);

--- a/cosmwasm/packages/schema/Cargo.toml
+++ b/cosmwasm/packages/schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-schema"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 authors = ["Simon Warta <webmaster128@users.noreply.github.com>", "Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "A dev-dependency for CosmWasm contracts to generate JSON Schema files."

--- a/cosmwasm/packages/sgx-vm/Cargo.toml
+++ b/cosmwasm/packages/sgx-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-sgx-vm"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 authors = [
     "Ethan Frey <ethanfrey@users.noreply.github.com>",
     "Enigma Team <info@enigma.co>",
@@ -35,7 +35,7 @@ staking = ["cosmwasm-std/staking"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "0.9.0-alpha1" }
+cosmwasm-std = { path = "../std", version = "0.9.0-alpha2" }
 serde_json = "1.0"
 wasmer-runtime-core = "0.17"
 wasmer-middleware-common = "0.17"

--- a/cosmwasm/packages/sgx-vm/src/context.rs
+++ b/cosmwasm/packages/sgx-vm/src/context.rs
@@ -366,7 +366,7 @@ mod test {
     #[cfg(feature = "iterator")]
     use crate::testing::MockIterator;
     use crate::testing::{MockQuerier, MockStorage};
-    use crate::traits::ReadonlyStorage;
+    use crate::traits::Storage;
     use cosmwasm_std::{
         coins, from_binary, to_vec, AllBalanceResponse, BankQuery, HumanAddr, Never, QueryRequest,
     };

--- a/cosmwasm/packages/sgx-vm/src/errors.rs
+++ b/cosmwasm/packages/sgx-vm/src/errors.rs
@@ -261,7 +261,7 @@ pub enum CommunicationError {
 }
 
 impl CommunicationError {
-    pub fn deref_err<S: Into<String>>(offset: u32, msg: S) -> Self {
+    pub(crate) fn deref_err<S: Into<String>>(offset: u32, msg: S) -> Self {
         DerefErr {
             offset,
             msg: msg.into(),
@@ -269,26 +269,27 @@ impl CommunicationError {
         .build()
     }
 
-    pub fn invalid_order(value: i32) -> Self {
+    #[allow(dead_code)]
+    pub(crate) fn invalid_order(value: i32) -> Self {
         InvalidOrder { value }.build()
     }
 
-    pub fn invalid_utf8<S: ToString>(msg: S) -> Self {
+    pub(crate) fn invalid_utf8<S: ToString>(msg: S) -> Self {
         InvalidUtf8 {
             msg: msg.to_string(),
         }
         .build()
     }
 
-    pub fn region_length_too_big(length: usize, max_length: usize) -> Self {
+    pub(crate) fn region_length_too_big(length: usize, max_length: usize) -> Self {
         RegionLengthTooBig { length, max_length }.build()
     }
 
-    pub fn region_too_small(size: usize, required: usize) -> Self {
+    pub(crate) fn region_too_small(size: usize, required: usize) -> Self {
         RegionTooSmall { size, required }.build()
     }
 
-    pub fn zero_address() -> Self {
+    pub(crate) fn zero_address() -> Self {
         ZeroAddress {}.build()
     }
 }

--- a/cosmwasm/packages/sgx-vm/src/imports.rs
+++ b/cosmwasm/packages/sgx-vm/src/imports.rs
@@ -200,7 +200,7 @@ mod test {
         move_into_context, set_storage_readonly, set_wasmer_instance, setup_context,
     };
     use crate::testing::{MockApi, MockQuerier, MockStorage};
-    use crate::traits::ReadonlyStorage;
+    use crate::traits::Storage;
     use crate::FfiError;
 
     static CONTRACT: &[u8] = include_bytes!("../testdata/contract.wasm");

--- a/cosmwasm/packages/sgx-vm/src/instance.rs
+++ b/cosmwasm/packages/sgx-vm/src/instance.rs
@@ -317,7 +317,7 @@ mod test {
         mock_instance_with_failing_api, mock_instance_with_gas_limit, MockApi, MockQuerier,
         MockStorage, MOCK_CONTRACT_ADDR,
     };
-    use crate::traits::ReadonlyStorage;
+    use crate::traits::Storage;
     use crate::{call_init, FfiError};
     use cosmwasm_std::{
         coin, from_binary, AllBalanceResponse, BalanceResponse, BankQuery, HumanAddr, Never,

--- a/cosmwasm/packages/sgx-vm/src/lib.rs
+++ b/cosmwasm/packages/sgx-vm/src/lib.rs
@@ -28,14 +28,16 @@ pub use crate::calls::{
     call_query, call_query_raw,
 };
 pub use crate::checksum::Checksum;
-pub use crate::errors::{FfiError, FfiResult, VmError, VmResult};
+pub use crate::errors::{
+    CommunicationError, CommunicationResult, FfiError, FfiResult, VmError, VmResult,
+};
 pub use crate::features::features_from_csv;
 pub use crate::instance::Instance;
 /*
 pub use crate::modules::FileSystemCache;
 */
 pub use crate::serde::{from_slice, to_vec};
-pub use crate::traits::{Api, Extern, Querier, QuerierResult, ReadonlyStorage, Storage};
+pub use crate::traits::{Api, Extern, Querier, QuerierResult, Storage};
 
 #[cfg(feature = "iterator")]
 pub use crate::traits::{NextItem, StorageIterator};

--- a/cosmwasm/packages/sgx-vm/src/testing/calls.rs
+++ b/cosmwasm/packages/sgx-vm/src/testing/calls.rs
@@ -16,17 +16,14 @@ use crate::{Api, Querier, Storage};
 // init mimicks the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn init<
+pub fn init<S, A, Q, M, U>(instance: &mut Instance<S, A, Q>, env: Env, msg: M) -> InitResult<U>
+where
     S: Storage + 'static,
     A: Api + 'static,
     Q: Querier + 'static,
-    T: Serialize + JsonSchema,
+    M: Serialize + JsonSchema,
     U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
->(
-    instance: &mut Instance<S, A, Q>,
-    env: Env,
-    msg: T,
-) -> InitResult<U> {
+{
     let serialized_msg = to_vec(&msg)?;
     call_init(instance, &env, &serialized_msg).expect("VM error")
 }
@@ -34,17 +31,14 @@ pub fn init<
 // handle mimicks the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn handle<
+pub fn handle<S, A, Q, M, U>(instance: &mut Instance<S, A, Q>, env: Env, msg: M) -> HandleResult<U>
+where
     S: Storage + 'static,
     A: Api + 'static,
     Q: Querier + 'static,
-    T: Serialize + JsonSchema,
+    M: Serialize + JsonSchema,
     U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
->(
-    instance: &mut Instance<S, A, Q>,
-    env: Env,
-    msg: T,
-) -> HandleResult<U> {
+{
     let serialized_msg = to_vec(&msg)?;
     call_handle(instance, &env, &serialized_msg).expect("VM error")
 }
@@ -52,17 +46,18 @@ pub fn handle<
 // migrate mimicks the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn migrate<
+pub fn migrate<S, A, Q, M, U>(
+    instance: &mut Instance<S, A, Q>,
+    env: Env,
+    msg: M,
+) -> MigrateResult<U>
+where
     S: Storage + 'static,
     A: Api + 'static,
     Q: Querier + 'static,
-    T: Serialize + JsonSchema,
+    M: Serialize + JsonSchema,
     U: DeserializeOwned + Clone + PartialEq + JsonSchema + fmt::Debug,
->(
-    instance: &mut Instance<S, A, Q>,
-    env: Env,
-    msg: T,
-) -> MigrateResult<U> {
+{
     let serialized_msg = to_vec(&msg)?;
     call_migrate(instance, &env, &serialized_msg).expect("VM error")
 }
@@ -70,15 +65,13 @@ pub fn migrate<
 // query mimicks the call signature of the smart contracts.
 // thus it moves env and msg rather than take them as reference.
 // this is inefficient here, but only used in test code
-pub fn query<
+pub fn query<S, A, Q, M>(instance: &mut Instance<S, A, Q>, msg: M) -> StdResult<QueryResponse>
+where
     S: Storage + 'static,
     A: Api + 'static,
     Q: Querier + 'static,
-    T: Serialize + JsonSchema,
->(
-    instance: &mut Instance<S, A, Q>,
-    msg: T,
-) -> StdResult<QueryResponse> {
+    M: Serialize + JsonSchema,
+{
     let serialized_msg = to_vec(&msg)?;
     call_query(instance, &serialized_msg).expect("VM error")
 }

--- a/cosmwasm/packages/sgx-vm/src/traits.rs
+++ b/cosmwasm/packages/sgx-vm/src/traits.rs
@@ -53,8 +53,8 @@ impl<I: StorageIterator + ?Sized> StorageIterator for Box<I> {
     }
 }
 
-/// ReadonlyStorage is access to the contracts persistent data store
-pub trait ReadonlyStorage
+/// Access to the VM's backend storage, i.e. the chain
+pub trait Storage
 where
     Self: 'static,
 {
@@ -78,11 +78,9 @@ where
         end: Option<&[u8]>,
         order: Order,
     ) -> FfiResult<(Box<dyn StorageIterator + 'a>, u64)>;
-}
 
-// Storage extends ReadonlyStorage to give mutable access
-pub trait Storage: ReadonlyStorage {
     fn set(&mut self, key: &[u8], value: &[u8]) -> FfiResult<u64>;
+
     /// Removes a database entry at `key`.
     ///
     /// The current interface does not allow to differentiate between a key that existed

--- a/cosmwasm/packages/std/Cargo.toml
+++ b/cosmwasm/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-std"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Standard library for Wasm based smart contracts on Cosmos blockchains"

--- a/cosmwasm/packages/std/schema/handle_result.json
+++ b/cosmwasm/packages/std/schema/handle_result.json
@@ -371,17 +371,6 @@
         {
           "type": "object",
           "required": [
-            "null_pointer"
-          ],
-          "properties": {
-            "null_pointer": {
-              "type": "object"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
             "parse_err"
           ],
           "properties": {

--- a/cosmwasm/packages/std/schema/init_result.json
+++ b/cosmwasm/packages/std/schema/init_result.json
@@ -361,17 +361,6 @@
         {
           "type": "object",
           "required": [
-            "null_pointer"
-          ],
-          "properties": {
-            "null_pointer": {
-              "type": "object"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
             "parse_err"
           ],
           "properties": {

--- a/cosmwasm/packages/std/schema/migrate_result.json
+++ b/cosmwasm/packages/std/schema/migrate_result.json
@@ -371,17 +371,6 @@
         {
           "type": "object",
           "required": [
-            "null_pointer"
-          ],
-          "properties": {
-            "null_pointer": {
-              "type": "object"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
             "parse_err"
           ],
           "properties": {

--- a/cosmwasm/packages/std/schema/query_result.json
+++ b/cosmwasm/packages/std/schema/query_result.json
@@ -114,17 +114,6 @@
         {
           "type": "object",
           "required": [
-            "null_pointer"
-          ],
-          "properties": {
-            "null_pointer": {
-              "type": "object"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
             "parse_err"
           ],
           "properties": {

--- a/cosmwasm/packages/std/src/encoding.rs
+++ b/cosmwasm/packages/std/src/encoding.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use schemars::JsonSchema;
 use serde::{de, ser, Deserialize, Deserializer, Serialize};
 
-use crate::errors::{invalid_base64, StdResult};
+use crate::errors::{StdError, StdResult};
 
 /// Binary is a wrapper around Vec<u8> to add base64 de/serialization
 /// with serde. It also adds some helper methods to help encode inline.
@@ -16,7 +16,7 @@ impl Binary {
     /// take an (untrusted) string and decode it into bytes.
     /// fails if it is not valid base64
     pub fn from_base64(encoded: &str) -> StdResult<Self> {
-        let binary = base64::decode(&encoded).map_err(invalid_base64)?;
+        let binary = base64::decode(&encoded).map_err(StdError::invalid_base64)?;
         Ok(Binary(binary))
     }
 

--- a/cosmwasm/packages/std/src/entry_points.rs
+++ b/cosmwasm/packages/std/src/entry_points.rs
@@ -1,0 +1,137 @@
+/// This macro generates the boilerplate required to call into the
+/// contract-specific logic from the entry-points to the Wasm module.
+///
+/// It should be invoked in a module scope(that is, not inside a function), and the argument to the macro
+/// should be the name of a second rust module that is imported in the invocation scope.
+/// The second module should export three functions with the following signatures:
+/// ```
+/// # use cosmwasm_std::{
+/// #     Storage, Api, Querier, Extern, Env, StdResult, Binary,
+/// #     InitResult, HandleResult, QueryResult,
+/// # };
+/// #
+/// # type InitMsg = ();
+/// pub fn init<S: Storage, A: Api, Q: Querier>(
+///     deps: &mut Extern<S, A, Q>,
+///     env: Env,
+///     msg: InitMsg,
+/// ) -> InitResult {
+/// #   Ok(Default::default())
+/// }
+///
+/// # type HandleMsg = ();
+/// pub fn handle<S: Storage, A: Api, Q: Querier>(
+///     deps: &mut Extern<S, A, Q>,
+///     env: Env,
+///     msg: HandleMsg,
+/// ) -> HandleResult {
+/// #   Ok(Default::default())
+/// }
+///
+/// # type QueryMsg = ();
+/// pub fn query<S: Storage, A: Api, Q: Querier>(
+///     deps: &Extern<S, A, Q>,
+///     msg: QueryMsg,
+/// ) -> QueryResult {
+/// #   Ok(Binary(Vec::new()))
+/// }
+/// ```
+/// Where `InitMsg`, `HandleMsg`, and `QueryMsg` are types that implement `DeserializeOwned + JsonSchema`
+///
+/// # Example
+///
+/// ```ignore
+/// use contract; // The contract module
+///
+/// cosmwasm_std::create_entry_points!(contract);
+/// ```
+#[macro_export]
+macro_rules! create_entry_points {
+    (@migration; $contract:ident, true) => {
+        #[no_mangle]
+        extern "C" fn migrate(env_ptr: u32, msg_ptr: u32) -> u32 {
+            do_migrate(
+                &$contract::migrate::<ExternalStorage, ExternalApi, ExternalQuerier>,
+                env_ptr,
+                msg_ptr,
+            )
+        }
+    };
+
+    (@migration; $contract:ident, false) => {};
+
+    (@inner; $contract:ident, migration = $migration:tt) => {
+        mod wasm {
+            use super::$contract;
+            use cosmwasm_std::{
+                do_handle, do_init, do_migrate, do_query, ExternalApi, ExternalQuerier,
+                ExternalStorage,
+            };
+
+            #[no_mangle]
+            extern "C" fn init(env_ptr: u32, msg_ptr: u32) -> u32 {
+                do_init(
+                    &$contract::init::<ExternalStorage, ExternalApi, ExternalQuerier>,
+                    env_ptr,
+                    msg_ptr,
+                )
+            }
+
+            #[no_mangle]
+            extern "C" fn handle(env_ptr: u32, msg_ptr: u32) -> u32 {
+                do_handle(
+                    &$contract::handle::<ExternalStorage, ExternalApi, ExternalQuerier>,
+                    env_ptr,
+                    msg_ptr,
+                )
+            }
+
+            #[no_mangle]
+            extern "C" fn query(msg_ptr: u32) -> u32 {
+                do_query(
+                    &$contract::query::<ExternalStorage, ExternalApi, ExternalQuerier>,
+                    msg_ptr,
+                )
+            }
+
+            $crate::create_entry_points!(@migration; $contract, $migration);
+
+            // Other C externs like cosmwasm_vm_version_1, allocate, deallocate are available
+            // automatically because we `use cosmwasm_std`.
+        }
+    };
+
+    ($contract:ident) => {
+        $crate::create_entry_points!(@inner; $contract, migration = false);
+    };
+}
+
+/// This macro is very similar to the `create_entry_points` macro, except it also requires the `migrate` method:
+/// ```
+/// # use cosmwasm_std::{
+/// #     Storage, Api, Querier, Extern, Env, StdResult, Binary, MigrateResult,
+/// # };
+/// # type MigrateMsg = ();
+/// pub fn migrate<S: Storage, A: Api, Q: Querier>(
+///     deps: &mut Extern<S, A, Q>,
+///     _env: Env,
+///     msg: MigrateMsg,
+/// ) -> MigrateResult {
+/// #   Ok(Default::default())
+/// }
+/// ```
+/// Where `MigrateMsg` is a type that implements `DeserializeOwned + JsonSchema`
+///
+/// # Example
+///
+/// ```ignore
+/// use contract; // The contract module
+///
+/// cosmwasm_std::create_entry_points_with_migration!(contract);
+/// ```
+#[macro_export]
+macro_rules! create_entry_points_with_migration {
+    ($contract:ident) => {
+        $crate::create_entry_points!(@inner; $contract, migration = true);
+    };
+}

--- a/cosmwasm/packages/std/src/errors/mod.rs
+++ b/cosmwasm/packages/std/src/errors/mod.rs
@@ -3,8 +3,9 @@ mod std_error_helpers;
 mod system_error;
 
 pub use std_error::{StdError, StdResult};
+#[allow(deprecated)]
 pub use std_error_helpers::{
-    generic_err, invalid_base64, invalid_utf8, not_found, null_pointer, parse_err, serialize_err,
-    unauthorized, underflow,
+    generic_err, invalid_base64, invalid_utf8, not_found, parse_err, serialize_err, unauthorized,
+    underflow,
 };
 pub use system_error::{SystemError, SystemResult};

--- a/cosmwasm/packages/std/src/errors/std_error.rs
+++ b/cosmwasm/packages/std/src/errors/std_error.rs
@@ -21,7 +21,6 @@ use snafu::Snafu;
 /// - Add creator function in std_error_helpers.rs
 /// - Regenerate schemas
 #[derive(Debug, Serialize, Deserialize, Snafu, JsonSchema)]
-#[snafu(visibility = "pub(crate)")]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum StdError {
@@ -48,11 +47,6 @@ pub enum StdError {
     #[snafu(display("{} not found", kind))]
     NotFound {
         kind: String,
-        #[serde(skip)]
-        backtrace: Option<snafu::Backtrace>,
-    },
-    #[snafu(display("Received null pointer, refuse to use"))]
-    NullPointer {
         #[serde(skip)]
         backtrace: Option<snafu::Backtrace>,
     },
@@ -85,6 +79,58 @@ pub enum StdError {
         #[serde(skip)]
         backtrace: Option<snafu::Backtrace>,
     },
+}
+
+impl StdError {
+    pub fn generic_err<S: Into<String>>(msg: S) -> Self {
+        GenericErr { msg: msg.into() }.build()
+    }
+
+    pub fn invalid_base64<S: ToString>(msg: S) -> Self {
+        InvalidBase64 {
+            msg: msg.to_string(),
+        }
+        .build()
+    }
+
+    pub fn invalid_utf8<S: ToString>(msg: S) -> Self {
+        InvalidUtf8 {
+            msg: msg.to_string(),
+        }
+        .build()
+    }
+
+    pub fn not_found<S: Into<String>>(kind: S) -> Self {
+        NotFound { kind: kind.into() }.build()
+    }
+
+    pub fn parse_err<T: Into<String>, M: ToString>(target: T, msg: M) -> Self {
+        ParseErr {
+            target: target.into(),
+            msg: msg.to_string(),
+        }
+        .build()
+    }
+
+    pub fn serialize_err<S: Into<String>, M: ToString>(source: S, msg: M) -> Self {
+        SerializeErr {
+            source: source.into(),
+            msg: msg.to_string(),
+        }
+        .build()
+    }
+
+    pub fn underflow<U: ToString>(minuend: U, subtrahend: U) -> Self {
+        Underflow {
+            minuend: minuend.to_string(),
+            subtrahend: subtrahend.to_string(),
+        }
+        .build()
+    }
+
+    pub fn unauthorized() -> Self {
+        Unauthorized {}.build()
+    }
 }
 
 impl PartialEq for StdError {
@@ -126,9 +172,6 @@ impl PartialEq for StdError {
                     backtrace: _,
                 },
             ) => kind == kind2,
-            (StdError::NullPointer { backtrace: _ }, StdError::NullPointer { backtrace: _ }) => {
-                true
-            }
             (
                 StdError::ParseErr {
                     target,
@@ -184,6 +227,151 @@ pub type StdResult<T> = core::result::Result<T, StdError>;
 mod test {
     use super::*;
     use crate::serde::{from_slice, to_vec};
+
+    // constructors
+
+    // example of reporting contract errors with format!
+    #[test]
+    fn generic_err_owned() {
+        let guess = 7;
+        let error = StdError::generic_err(format!("{} is too low", guess));
+        match error {
+            StdError::GenericErr { msg, .. } => {
+                assert_eq!(msg, String::from("7 is too low"));
+            }
+            e => panic!("unexpected error, {:?}", e),
+        }
+    }
+
+    // example of reporting static contract errors
+    #[test]
+    fn generic_err_ref() {
+        let error = StdError::generic_err("not implemented");
+        match error {
+            StdError::GenericErr { msg, .. } => assert_eq!(msg, "not implemented"),
+            e => panic!("unexpected error, {:?}", e),
+        }
+    }
+
+    #[test]
+    fn invalid_base64_works_for_strings() {
+        let error = StdError::invalid_base64("my text");
+        match error {
+            StdError::InvalidBase64 { msg, .. } => {
+                assert_eq!(msg, "my text");
+            }
+            _ => panic!("expect different error"),
+        }
+    }
+
+    #[test]
+    fn invalid_base64_works_for_errors() {
+        let original = base64::DecodeError::InvalidLength;
+        let error = StdError::invalid_base64(original);
+        match error {
+            StdError::InvalidBase64 { msg, .. } => {
+                assert_eq!(msg, "Encoded text cannot have a 6-bit remainder.");
+            }
+            _ => panic!("expect different error"),
+        }
+    }
+
+    #[test]
+    fn invalid_utf8_works_for_strings() {
+        let error = StdError::invalid_utf8("my text");
+        match error {
+            StdError::InvalidUtf8 { msg, .. } => {
+                assert_eq!(msg, "my text");
+            }
+            _ => panic!("expect different error"),
+        }
+    }
+
+    #[test]
+    fn invalid_utf8_works_for_errors() {
+        let original = String::from_utf8(vec![0x80]).unwrap_err();
+        let error = StdError::invalid_utf8(original);
+        match error {
+            StdError::InvalidUtf8 { msg, .. } => {
+                assert_eq!(msg, "invalid utf-8 sequence of 1 bytes from index 0");
+            }
+            _ => panic!("expect different error"),
+        }
+    }
+
+    #[test]
+    fn not_found_works() {
+        let error = StdError::not_found("gold");
+        match error {
+            StdError::NotFound { kind, .. } => assert_eq!(kind, "gold"),
+            _ => panic!("expect different error"),
+        }
+    }
+
+    #[test]
+    fn parse_err_works() {
+        let error = StdError::parse_err("Book", "Missing field: title");
+        match error {
+            StdError::ParseErr { target, msg, .. } => {
+                assert_eq!(target, "Book");
+                assert_eq!(msg, "Missing field: title");
+            }
+            _ => panic!("expect different error"),
+        }
+    }
+
+    #[test]
+    fn serialize_err_works() {
+        let error = StdError::serialize_err("Book", "Content too long");
+        match error {
+            StdError::SerializeErr { source, msg, .. } => {
+                assert_eq!(source, "Book");
+                assert_eq!(msg, "Content too long");
+            }
+            _ => panic!("expect different error"),
+        }
+    }
+
+    #[test]
+    fn underflow_works_for_u128() {
+        let error = StdError::underflow(123u128, 456u128);
+        match error {
+            StdError::Underflow {
+                minuend,
+                subtrahend,
+                ..
+            } => {
+                assert_eq!(minuend, "123");
+                assert_eq!(subtrahend, "456");
+            }
+            _ => panic!("expect different error"),
+        }
+    }
+
+    #[test]
+    fn underflow_works_for_i64() {
+        let error = StdError::underflow(777i64, 1234i64);
+        match error {
+            StdError::Underflow {
+                minuend,
+                subtrahend,
+                ..
+            } => {
+                assert_eq!(minuend, "777");
+                assert_eq!(subtrahend, "1234");
+            }
+            _ => panic!("expect different error"),
+        }
+    }
+
+    #[test]
+    fn unauthorized_works() {
+        let error = StdError::unauthorized();
+        match error {
+            StdError::Unauthorized { .. } => {}
+            _ => panic!("expect different error"),
+        }
+    }
 
     #[test]
     fn can_serialize() {
@@ -277,11 +465,6 @@ mod test {
     #[test]
     fn unauthorized_conversion() {
         assert_conversion(Unauthorized {}.build());
-    }
-
-    #[test]
-    fn null_pointer_conversion() {
-        assert_conversion(NullPointer {}.build());
     }
 
     #[test]

--- a/cosmwasm/packages/std/src/errors/std_error_helpers.rs
+++ b/cosmwasm/packages/std/src/errors/std_error_helpers.rs
@@ -1,64 +1,48 @@
 use std::fmt::Display;
 
-use super::std_error::{
-    GenericErr, InvalidBase64, InvalidUtf8, NotFound, NullPointer, ParseErr, SerializeErr,
-    StdError, Unauthorized, Underflow,
-};
+use super::std_error::StdError;
 
+#[deprecated(note = "Please use StdError::generic_err function instead")]
 pub fn generic_err<S: Into<String>>(msg: S) -> StdError {
-    GenericErr { msg: msg.into() }.build()
+    StdError::generic_err(msg)
 }
 
+#[deprecated(note = "Please use StdError::invalid_base64 function instead")]
 pub fn invalid_base64<S: Display>(msg: S) -> StdError {
-    InvalidBase64 {
-        msg: msg.to_string(),
-    }
-    .build()
+    StdError::invalid_base64(msg)
 }
 
+#[deprecated(note = "Please use StdError::invalid_utf8 function instead")]
 pub fn invalid_utf8<S: Display>(msg: S) -> StdError {
-    InvalidUtf8 {
-        msg: msg.to_string(),
-    }
-    .build()
+    StdError::invalid_utf8(msg)
 }
 
+#[deprecated(note = "Please use StdError::not_found function instead")]
 pub fn not_found<S: Into<String>>(kind: S) -> StdError {
-    NotFound { kind: kind.into() }.build()
+    StdError::not_found(kind)
 }
 
-pub fn null_pointer() -> StdError {
-    NullPointer {}.build()
-}
-
+#[deprecated(note = "Please use StdError::parse_err function instead")]
 pub fn parse_err<T: Into<String>, M: Display>(target: T, msg: M) -> StdError {
-    ParseErr {
-        target: target.into(),
-        msg: msg.to_string(),
-    }
-    .build()
+    StdError::parse_err(target, msg)
 }
 
+#[deprecated(note = "Please use StdError::serialize_err function instead")]
 pub fn serialize_err<S: Into<String>, M: Display>(source: S, msg: M) -> StdError {
-    SerializeErr {
-        source: source.into(),
-        msg: msg.to_string(),
-    }
-    .build()
+    StdError::serialize_err(source, msg)
 }
 
+#[deprecated(note = "Please use StdError::underflow function instead")]
 pub fn underflow<U: ToString>(minuend: U, subtrahend: U) -> StdError {
-    Underflow {
-        minuend: minuend.to_string(),
-        subtrahend: subtrahend.to_string(),
-    }
-    .build()
+    StdError::underflow(minuend, subtrahend)
 }
 
+#[deprecated(note = "Please use StdError::unauthorized function instead")]
 pub fn unauthorized() -> StdError {
-    Unauthorized {}.build()
+    StdError::unauthorized()
 }
 
+#[allow(deprecated)]
 #[cfg(test)]
 mod test {
     use super::super::std_error::StdError;
@@ -138,15 +122,6 @@ mod test {
         let error: StdError = not_found("gold");
         match error {
             StdError::NotFound { kind, .. } => assert_eq!(kind, "gold"),
-            _ => panic!("expect different error"),
-        }
-    }
-
-    #[test]
-    fn null_pointer_works() {
-        let error: StdError = null_pointer();
-        match error {
-            StdError::NullPointer { .. } => {}
             _ => panic!("expect different error"),
         }
     }

--- a/cosmwasm/packages/std/src/imports.rs
+++ b/cosmwasm/packages/std/src/imports.rs
@@ -1,7 +1,7 @@
 use std::vec::Vec;
 
 use crate::encoding::Binary;
-use crate::errors::{generic_err, StdResult};
+use crate::errors::{StdError, StdResult};
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, KV};
 use crate::memory::{alloc, build_region, consume_region, Region};
@@ -159,7 +159,7 @@ impl Api for ExternalApi {
 
         let read = unsafe { canonicalize_address(send_ptr, canon as u32) };
         if read < 0 {
-            return Err(generic_err("canonicalize_address returned error"));
+            return Err(StdError::generic_err("canonicalize_address returned error"));
         }
 
         let out = unsafe { consume_region(canon) };
@@ -173,7 +173,7 @@ impl Api for ExternalApi {
 
         let read = unsafe { humanize_address(send_ptr, human as u32) };
         if read < 0 {
-            return Err(generic_err("humanize_address returned error"));
+            return Err(StdError::generic_err("humanize_address returned error"));
         }
 
         let out = unsafe { consume_region(human) };

--- a/cosmwasm/packages/std/src/iterator.rs
+++ b/cosmwasm/packages/std/src/iterator.rs
@@ -1,4 +1,4 @@
-use crate::errors::{generic_err, StdError};
+use crate::errors::StdError;
 use std::convert::TryFrom;
 
 /// KV is a Key-Value pair, returned from our iterators
@@ -18,7 +18,7 @@ impl TryFrom<i32> for Order {
         match value {
             1 => Ok(Order::Ascending),
             2 => Ok(Order::Descending),
-            _ => Err(generic_err("Order must be 1 or 2")),
+            _ => Err(StdError::generic_err("Order must be 1 or 2")),
         }
     }
 }

--- a/cosmwasm/packages/std/src/lib.rs
+++ b/cosmwasm/packages/std/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod coins;
 mod encoding;
+mod entry_points;
 mod errors;
 mod init_handle;
 #[cfg(feature = "iterator")]
@@ -15,9 +16,10 @@ mod types;
 
 pub use crate::coins::{coin, coins, has_coins, Coin};
 pub use crate::encoding::Binary;
+#[allow(deprecated)]
 pub use crate::errors::{
-    generic_err, invalid_base64, invalid_utf8, not_found, null_pointer, parse_err, serialize_err,
-    unauthorized, underflow, StdError, StdResult, SystemError, SystemResult,
+    generic_err, invalid_base64, invalid_utf8, not_found, parse_err, serialize_err, unauthorized,
+    underflow, StdError, StdResult, SystemError, SystemResult,
 };
 pub use crate::init_handle::{
     log, BankMsg, CosmosMsg, HandleResponse, HandleResult, InitResponse, InitResult, LogAttribute,

--- a/cosmwasm/packages/std/src/mock.rs
+++ b/cosmwasm/packages/std/src/mock.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::coins::Coin;
 use crate::encoding::Binary;
-use crate::errors::{generic_err, invalid_utf8, StdResult, SystemError, SystemResult};
+use crate::errors::{StdError, StdResult, SystemError, SystemResult};
 use crate::query::{
     AllBalanceResponse, AllDelegationsResponse, BalanceResponse, BankQuery, BondedDenomResponse,
     DelegationResponse, FullDelegation, QueryRequest, StakingQuery, Validator, ValidatorsResponse,
@@ -71,10 +71,14 @@ impl Api for MockApi {
     fn canonical_address(&self, human: &HumanAddr) -> StdResult<CanonicalAddr> {
         // Dummy input validation. This is more sophisticated for formats like bech32, where format and checksum are validated.
         if human.len() < 3 {
-            return Err(generic_err("Invalid input: human address too short"));
+            return Err(StdError::generic_err(
+                "Invalid input: human address too short",
+            ));
         }
         if human.len() > self.canonical_length {
-            return Err(generic_err("Invalid input: human address too long"));
+            return Err(StdError::generic_err(
+                "Invalid input: human address too long",
+            ));
         }
 
         let mut out = Vec::from(human.as_str());
@@ -87,7 +91,7 @@ impl Api for MockApi {
 
     fn human_address(&self, canonical: &CanonicalAddr) -> StdResult<HumanAddr> {
         if canonical.len() != self.canonical_length {
-            return Err(generic_err(
+            return Err(StdError::generic_err(
                 "Invalid input: canonical address length not correct",
             ));
         }
@@ -100,7 +104,7 @@ impl Api for MockApi {
             .filter(|&x| x != 0)
             .collect();
         // decode UTF-8 bytes into string
-        let human = String::from_utf8(trimmed).map_err(invalid_utf8)?;
+        let human = String::from_utf8(trimmed).map_err(StdError::invalid_utf8)?;
         Ok(HumanAddr(human))
     }
 }

--- a/cosmwasm/packages/std/src/serde.rs
+++ b/cosmwasm/packages/std/src/serde.rs
@@ -6,10 +6,10 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::any::type_name;
 
 use crate::encoding::Binary;
-use crate::errors::{parse_err, serialize_err, StdResult};
+use crate::errors::{StdError, StdResult};
 
 pub fn from_slice<T: DeserializeOwned>(value: &[u8]) -> StdResult<T> {
-    serde_json_wasm::from_slice(value).map_err(|e| parse_err(type_name::<T>(), e))
+    serde_json_wasm::from_slice(value).map_err(|e| StdError::parse_err(type_name::<T>(), e))
 }
 
 pub fn from_binary<T: DeserializeOwned>(value: &Binary) -> StdResult<T> {
@@ -20,7 +20,7 @@ pub fn to_vec<T>(data: &T) -> StdResult<Vec<u8>>
 where
     T: Serialize + ?Sized,
 {
-    serde_json_wasm::to_vec(data).map_err(|e| serialize_err(type_name::<T>(), e))
+    serde_json_wasm::to_vec(data).map_err(|e| StdError::serialize_err(type_name::<T>(), e))
 }
 
 pub fn to_binary<T>(data: &T) -> StdResult<Binary>

--- a/cosmwasm/packages/std/src/traits.rs
+++ b/cosmwasm/packages/std/src/traits.rs
@@ -2,7 +2,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::coins::Coin;
 use crate::encoding::Binary;
-use crate::errors::{generic_err, StdResult, SystemResult};
+use crate::errors::{StdError, StdResult, SystemResult};
 #[cfg(feature = "iterator")]
 use crate::iterator::{Order, KV};
 use crate::query::{AllBalanceResponse, BalanceResponse, BankQuery, QueryRequest};
@@ -114,10 +114,18 @@ pub trait Querier {
     ) -> StdResult<U> {
         let raw = match to_vec(request) {
             Ok(raw) => raw,
-            Err(e) => return Err(generic_err(format!("Serializing QueryRequest: {}", e))),
+            Err(e) => {
+                return Err(StdError::generic_err(format!(
+                    "Serializing QueryRequest: {}",
+                    e
+                )))
+            }
         };
         match self.raw_query(&raw) {
-            Err(sys) => Err(generic_err(format!("Querier system error: {}", sys))),
+            Err(sys) => Err(StdError::generic_err(format!(
+                "Querier system error: {}",
+                sys
+            ))),
             Ok(Err(err)) => Err(err),
             // in theory we would process the response, but here it is the same type, so just pass through
             Ok(Ok(res)) => from_binary(&res),

--- a/cosmwasm/packages/storage/Cargo.toml
+++ b/cosmwasm/packages/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-storage"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm library with useful helpers for Storage patterns"
@@ -19,7 +19,7 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "0.9.0-alpha1" }
+cosmwasm-std = { path = "../std", version = "0.9.0-alpha2" }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 
 [dev-dependencies]

--- a/cosmwasm/packages/storage/src/bucket.rs
+++ b/cosmwasm/packages/storage/src/bucket.rs
@@ -168,7 +168,7 @@ where
 mod test {
     use super::*;
     use cosmwasm_std::testing::MockStorage;
-    use cosmwasm_std::{generic_err, not_found};
+    use cosmwasm_std::StdError;
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -267,7 +267,7 @@ mod test {
 
         // it's my birthday
         let birthday = |mayd: Option<Data>| -> StdResult<Data> {
-            let mut d = mayd.ok_or(not_found("Data"))?;
+            let mut d = mayd.ok_or(StdError::not_found("Data"))?;
             d.age += 1;
             Ok(d)
         };
@@ -297,7 +297,7 @@ mod test {
         let mut old_age = 0i32;
         bucket
             .update(b"maria", |mayd: Option<Data>| {
-                let mut d = mayd.ok_or(not_found("Data"))?;
+                let mut d = mayd.ok_or(StdError::not_found("Data"))?;
                 old_age = d.age;
                 d.age += 1;
                 Ok(d)
@@ -319,7 +319,9 @@ mod test {
         bucket.save(b"maria", &init).unwrap();
 
         // it's my birthday
-        let output = bucket.update(b"maria", |_d| Err(generic_err("cuz i feel like it")));
+        let output = bucket.update(b"maria", |_d| {
+            Err(StdError::generic_err("cuz i feel like it"))
+        });
         assert!(output.is_err());
 
         // load it properly
@@ -340,7 +342,7 @@ mod test {
         // it's my birthday
         let output = bucket
             .update(b"maria", |d| match d {
-                Some(_) => Err(generic_err("Ensure this was empty")),
+                Some(_) => Err(StdError::generic_err("Ensure this was empty")),
                 None => Ok(init_value.clone()),
             })
             .unwrap();

--- a/cosmwasm/packages/storage/src/singleton.rs
+++ b/cosmwasm/packages/storage/src/singleton.rs
@@ -129,7 +129,7 @@ mod test {
     use cosmwasm_std::testing::MockStorage;
     use serde::{Deserialize, Serialize};
 
-    use cosmwasm_std::{unauthorized, StdError};
+    use cosmwasm_std::StdError;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Config {
@@ -227,7 +227,7 @@ mod test {
         };
         writer.save(&cfg).unwrap();
 
-        let output = writer.update(&|_c| Err(unauthorized()));
+        let output = writer.update(&|_c| Err(StdError::unauthorized()));
         match output {
             Err(StdError::Unauthorized { .. }) => {}
             _ => panic!("Unexpected output: {:?}", output),

--- a/cosmwasm/packages/storage/src/transactions.rs
+++ b/cosmwasm/packages/storage/src/transactions.rs
@@ -272,7 +272,7 @@ fn range_bounds(start: Option<&[u8]>, end: Option<&[u8]>) -> impl RangeBounds<Ve
 #[cfg(test)]
 mod test {
     use super::*;
-    use cosmwasm_std::{unauthorized, MemoryStorage};
+    use cosmwasm_std::{MemoryStorage, StdError};
 
     #[cfg(feature = "iterator")]
     // iterator_test_suite takes a storage, adds data and runs iterator tests
@@ -557,7 +557,7 @@ mod test {
             assert_eq!(store.get(b"good"), Some(b"one".to_vec()));
             // we write in the Error case
             store.set(b"bad", b"value");
-            Err(unauthorized())
+            Err(StdError::unauthorized())
         });
         assert!(res.is_err());
         assert_eq!(base.get(b"bad"), None);

--- a/cosmwasm/packages/storage/src/type_helpers.rs
+++ b/cosmwasm/packages/storage/src/type_helpers.rs
@@ -3,7 +3,7 @@ use std::any::type_name;
 
 #[cfg(feature = "iterator")]
 use cosmwasm_std::KV;
-use cosmwasm_std::{from_slice, not_found, StdResult};
+use cosmwasm_std::{from_slice, StdError, StdResult};
 
 /// may_deserialize parses json bytes from storage (Option), returning Ok(None) if no data present
 ///
@@ -13,7 +13,7 @@ pub(crate) fn may_deserialize<T: DeserializeOwned>(
     value: &Option<Vec<u8>>,
 ) -> StdResult<Option<T>> {
     match value {
-        Some(d) => Ok(Some(from_slice(d.as_slice())?)),
+        Some(vec) => Ok(Some(from_slice(&vec)?)),
         None => Ok(None),
     }
 }
@@ -21,8 +21,8 @@ pub(crate) fn may_deserialize<T: DeserializeOwned>(
 /// must_deserialize parses json bytes from storage (Option), returning NotFound error if no data present
 pub(crate) fn must_deserialize<T: DeserializeOwned>(value: &Option<Vec<u8>>) -> StdResult<T> {
     match value {
-        Some(d) => from_slice(&d),
-        None => Err(not_found(type_name::<T>())),
+        Some(vec) => from_slice(&vec),
+        None => Err(StdError::not_found(type_name::<T>())),
     }
 }
 
@@ -40,43 +40,50 @@ mod test {
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-    struct Data {
+    struct Person {
         pub name: String,
         pub age: i32,
     }
 
     #[test]
-    fn serialize_and_deserialize() {
-        // save data
-        let data = Data {
+    fn may_deserialize_handles_some() {
+        let person = Person {
             name: "Maria".to_string(),
             age: 42,
         };
-        let value = to_vec(&data).unwrap();
-        let loaded = Some(value);
+        let value = to_vec(&person).unwrap();
 
-        //        let parsed: Data = deserialize(loaded.map(|s| s.as_slice())).unwrap();
-        //        assert_eq!(parsed, data);
-        let parsed: Data = must_deserialize(&loaded).unwrap();
-        assert_eq!(parsed, data);
-
-        let may_parse: Option<Data> = may_deserialize(&loaded).unwrap();
-        assert_eq!(may_parse, Some(data));
+        let may_parse: Option<Person> = may_deserialize(&Some(value)).unwrap();
+        assert_eq!(may_parse, Some(person));
     }
 
     #[test]
-    fn handle_none() {
-        let may_parse = may_deserialize::<Data>(&None).unwrap();
+    fn may_deserialize_handles_none() {
+        let may_parse = may_deserialize::<Person>(&None).unwrap();
         assert_eq!(may_parse, None);
+    }
 
-        let parsed = must_deserialize::<Data>(&None);
-        match parsed {
-            // if we used short_type_name, this would just be Data
-            Err(StdError::NotFound { kind, .. }) => {
-                assert_eq!(kind, "cosmwasm_storage::type_helpers::test::Data")
+    #[test]
+    fn must_deserialize_handles_some() {
+        let person = Person {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        let value = to_vec(&person).unwrap();
+        let loaded = Some(value);
+
+        let parsed: Person = must_deserialize(&loaded).unwrap();
+        assert_eq!(parsed, person);
+    }
+
+    #[test]
+    fn must_deserialize_handles_none() {
+        let parsed = must_deserialize::<Person>(&None);
+        match parsed.unwrap_err() {
+            StdError::NotFound { kind, .. } => {
+                assert_eq!(kind, "cosmwasm_storage::type_helpers::test::Person")
             }
-            Err(e) => panic!("Unexpected error {}", e),
-            Ok(_) => panic!("should error"),
+            e => panic!("Unexpected error {}", e),
         }
     }
 }

--- a/cosmwasm/packages/storage/src/typed.rs
+++ b/cosmwasm/packages/storage/src/typed.rs
@@ -143,7 +143,7 @@ where
 mod test {
     use super::*;
     use cosmwasm_std::testing::MockStorage;
-    use cosmwasm_std::{generic_err, not_found};
+    use cosmwasm_std::StdError;
     use serde::{Deserialize, Serialize};
 
     use crate::prefixed;
@@ -230,7 +230,7 @@ mod test {
 
         // it's my birthday (fail if no data)
         let birthday = |mayd: Option<Data>| -> StdResult<Data> {
-            let mut d = mayd.ok_or(not_found("Data"))?;
+            let mut d = mayd.ok_or(StdError::not_found("Data"))?;
             d.age += 1;
             Ok(d)
         };
@@ -259,7 +259,9 @@ mod test {
         bucket.save(b"maria", &init).unwrap();
 
         // it's my birthday
-        let output = bucket.update(b"maria", |_d| Err(generic_err("cuz i feel like it")));
+        let output = bucket.update(b"maria", |_d| {
+            Err(StdError::generic_err("cuz i feel like it"))
+        });
         assert!(output.is_err());
 
         // load it properly
@@ -280,7 +282,7 @@ mod test {
         // it's my birthday
         let output = bucket
             .update(b"maria", |d| match d {
-                Some(_) => Err(generic_err("Ensure this was empty")),
+                Some(_) => Err(StdError::generic_err("Ensure this was empty")),
                 None => Ok(init_value.clone()),
             })
             .unwrap();


### PR DESCRIPTION
This PR copies the contents of the `7429ac1` commit from `enigmampc/cosmwasm`.
It merges the latest commit on the `cosmwasm-0.9` branch in this repo (fb608de8) with the latest commit on the `master` branch of `CosmWasm/cosmwasm` (`753578c`, also tag `v0.9.0-alpha2`).

The new content includes: (bold is interesting)
* Remove StdError::NullPointer/null_pointer
* Move error creators into StdError (previously they were free functions)
* **added `entry_points!` macro**
* **Merge ReadonlyStorage into Storage**

To the reviewers, please try to `git merge origin/upstream-cosmwasm-7429ac1` this branch to your branches and let me know if you got any conflicts. If you don't then please approve this PR. I will merge it once i have all 3 approvals.
Of course, you don't have to keep that merge commit, and instead reset to your original commit, and merge later.