### PR TITLE
Upstream enigmampc/go-cosmwasm de9dfbb

### DIFF
--- a/go-cosmwasm/Cargo.lock
+++ b/go-cosmwasm/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli",
 ]
@@ -244,7 +244,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-sgx-vm"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.12.2",
  "cosmwasm-std",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.9.0-alpha1"
+version = "0.9.0-alpha2"
 dependencies = [
  "base64 0.11.0",
  "schemars",
@@ -392,7 +392,7 @@ checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "go-cosmwasm"
-version = "0.8.0"
+version = "0.9.0-alpha2"
 dependencies = [
  "cbindgen 0.14.2",
  "cosmwasm-sgx-vm",
@@ -726,9 +726,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -880,9 +880,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/go-cosmwasm/Cargo.toml
+++ b/go-cosmwasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-cosmwasm"
-version = "0.8.0"
+version = "0.9.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Go bindings for cosmwasm contracts"
@@ -10,9 +10,10 @@ readme = "README.md"
 exclude = [".circleci/*", ".gitignore"]
 
 [lib]
-#crate-type = ["staticlib"]
 crate-type = ["cdylib"]
 
+# the example is to allow us to compile a muslc static lib with the same codebase as we compile the
+# normal dynamic libs (best workaround I could find to override crate-type on the command line)
 [[example]]
 name = "muslc"
 path = "src/lib.rs"

--- a/go-cosmwasm/Makefile
+++ b/go-cosmwasm/Makefile
@@ -107,6 +107,9 @@ build-go:
 test:
 	RUST_BACKTRACE=1 go test -v ./api ./types .
 
+test-safety:
+	GODEBUG=cgocheck=2 go test -race -v -count 1 ./api
+
 # we should build all the docker images locally ONCE and publish them
 docker-image-centos7:
 	docker build . -t cosmwasm/go-ext-builder:$(DOCKER_TAG)-centos7 -f ./Dockerfile.centos7

--- a/go-cosmwasm/api/bindings.h
+++ b/go-cosmwasm/api/bindings.h
@@ -65,16 +65,17 @@ typedef struct db_t {
 } db_t;
 
 typedef struct iterator_t {
-  uint8_t _private[0];
+  uint64_t db_counter;
+  uint64_t iterator_index;
 } iterator_t;
 
 typedef struct Iterator_vtable {
-  int32_t (*next_db)(iterator_t*, gas_meter_t*, uint64_t*, Buffer*, Buffer*);
+  int32_t (*next_db)(iterator_t, gas_meter_t*, uint64_t*, Buffer*, Buffer*);
 } Iterator_vtable;
 
 typedef struct GoIter {
   gas_meter_t *gas_meter;
-  iterator_t *state;
+  iterator_t state;
   Iterator_vtable vtable;
 } GoIter;
 

--- a/go-cosmwasm/api/callbacks.go
+++ b/go-cosmwasm/api/callbacks.go
@@ -9,7 +9,7 @@ typedef GoResult (*write_db_fn)(db_t *ptr, gas_meter_t *gas_meter, uint64_t *use
 typedef GoResult (*remove_db_fn)(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer key);
 typedef GoResult (*scan_db_fn)(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer start, Buffer end, int32_t order, GoIter *out);
 // iterator
-typedef GoResult (*next_db_fn)(iterator_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer *key, Buffer *val);
+typedef GoResult (*next_db_fn)(iterator_t idx, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer *key, Buffer *val);
 // and api
 typedef GoResult (*humanize_address_fn)(api_t*, Buffer, Buffer*);
 typedef GoResult (*canonicalize_address_fn)(api_t*, Buffer, Buffer*);
@@ -27,6 +27,8 @@ GoResult cHumanAddress_cgo(api_t *ptr, Buffer canon, Buffer *human);
 GoResult cCanonicalAddress_cgo(api_t *ptr, Buffer human, Buffer *canon);
 // and querier
 GoResult cQueryExternal_cgo(querier_t *ptr, uint64_t *used_gas, Buffer request, Buffer *result);
+
+
 */
 import "C"
 
@@ -121,12 +123,29 @@ var db_vtable = C.DB_vtable{
 	scan_db:   (C.scan_db_fn)(C.cScan_cgo),
 }
 
+type DBState struct {
+	Store KVStore
+	// IteratorStackID is used to lookup the proper stack frame for iterators associated with this DB (iterator.go)
+	IteratorStackID uint64
+}
+
+// use this to create C.DB in two steps, so the pointer lives as long as the calling stack
+//   state := buildDBState(kv, counter)
+//   db := buildDB(&state, &gasMeter)
+//   // then pass db into some FFI function
+func buildDBState(kv KVStore, counter uint64) DBState {
+	return DBState{
+		Store:           kv,
+		IteratorStackID: counter,
+	}
+}
+
 // contract: original pointer/struct referenced must live longer than C.DB struct
 // since this is only used internally, we can verify the code that this is the case
-func buildDB(kv *KVStore, gm *GasMeter) C.DB {
+func buildDB(state *DBState, gm *GasMeter) C.DB {
 	return C.DB{
 		gas_meter: (*C.gas_meter_t)(unsafe.Pointer(gm)),
-		state:     (*C.db_t)(unsafe.Pointer(kv)),
+		state:     (*C.db_t)(unsafe.Pointer(state)),
 		vtable:    db_vtable,
 	}
 }
@@ -137,16 +156,16 @@ var iterator_vtable = C.Iterator_vtable{
 
 // contract: original pointer/struct referenced must live longer than C.DB struct
 // since this is only used internally, we can verify the code that this is the case
-func buildIterator(it dbm.Iterator, gasMeter *C.gas_meter_t) C.GoIter {
-	return C.GoIter{
-		gas_meter: gasMeter,
-		state:     (*C.iterator_t)(unsafe.Pointer(&it)),
-		vtable:    iterator_vtable,
+func buildIterator(dbCounter uint64, it dbm.Iterator) C.iterator_t {
+	idx := storeIterator(dbCounter, it)
+	return C.iterator_t{
+		db_counter:     u64(dbCounter),
+		iterator_index: u64(idx),
 	}
 }
 
 //export cGet
-func cGet(ptr *C.db_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key C.Buffer, val *C.Buffer) (ret C.GoResult) {
+func cGet(ptr *C.db_t, gasMeter *C.gas_meter_t, usedGas *u64, key C.Buffer, val *C.Buffer) (ret C.GoResult) {
 	defer recoverPanic(&ret)
 	if ptr == nil || gasMeter == nil || usedGas == nil || val == nil {
 		// we received an invalid pointer
@@ -160,7 +179,7 @@ func cGet(ptr *C.db_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key C.Buffe
 	gasBefore := gm.GasConsumed()
 	v := kv.Get(k)
 	gasAfter := gm.GasConsumed()
-	*usedGas = (C.uint64_t)((gasAfter - gasBefore) * GasMultiplier)
+	*usedGas = (u64)((gasAfter - gasBefore) * GasMultiplier)
 
 	// v will equal nil when the key is missing
 	// https://github.com/cosmos/cosmos-sdk/blob/1083fa948e347135861f88e07ec76b0314296832/store/types/store.go#L174
@@ -224,7 +243,8 @@ func cScan(ptr *C.db_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, start C.Bu
 	}
 
 	gm := *(*GasMeter)(unsafe.Pointer(gasMeter))
-	kv := *(*KVStore)(unsafe.Pointer(ptr))
+	state := (*DBState)(unsafe.Pointer(ptr))
+	kv := state.Store
 	// handle null as well as data
 	var s, e []byte
 	if start.ptr != nil {
@@ -247,13 +267,13 @@ func cScan(ptr *C.db_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, start C.Bu
 	gasAfter := gm.GasConsumed()
 	*usedGas = (C.uint64_t)((gasAfter - gasBefore) * GasMultiplier)
 
-	// Let's hope this works!
-	*out = buildIterator(iter, gasMeter)
+	out.state = buildIterator(state.IteratorStackID, iter)
+	out.vtable = iterator_vtable
 	return C.GoResult_Ok
 }
 
 //export cNext
-func cNext(ptr *C.iterator_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key *C.Buffer, val *C.Buffer) (ret C.GoResult) {
+func cNext(ref C.iterator_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key *C.Buffer, val *C.Buffer) (ret C.GoResult) {
 	// typical usage of iterator
 	// 	for ; itr.Valid(); itr.Next() {
 	// 		k, v := itr.Key(); itr.Value()
@@ -261,13 +281,13 @@ func cNext(ptr *C.iterator_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key 
 	// 	}
 
 	defer recoverPanic(&ret)
-	if ptr == nil || gasMeter == nil || usedGas == nil || key == nil || val == nil {
+	if ref.db_counter == 0 || gasMeter == nil || usedGas == nil || key == nil || val == nil {
 		// we received an invalid pointer
 		return C.GoResult_BadArgument
 	}
 
 	gm := *(*GasMeter)(unsafe.Pointer(gasMeter))
-	iter := *(*dbm.Iterator)(unsafe.Pointer(ptr))
+	iter := retrieveIterator(uint64(ref.db_counter), uint64(ref.iterator_index))
 	if !iter.Valid() {
 		// end of iterator, return as no-op, nil key is considered end
 		return C.GoResult_Ok

--- a/go-cosmwasm/api/iterator.go
+++ b/go-cosmwasm/api/iterator.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	dbm "github.com/tendermint/tm-db"
+	"sync"
+)
+
+// frame stores all Iterators for one contract
+type frame []dbm.Iterator
+
+// iteratorStack contains one frame for each contract, indexed by a counter
+// 10 is a rather arbitrary guess on how many frames might be needed simultaneously
+var iteratorStack = make(map[uint64]frame, 10)
+var iteratorStackMutex sync.Mutex
+
+// this is a global counter when we create DBs
+var dbCounter uint64
+var dbCounterMutex sync.Mutex
+
+// startContract is called at the beginning of a contract runtime to create a new frame on the iteratorStack
+// updates dbCounter for an index
+func startContract() uint64 {
+	dbCounterMutex.Lock()
+	defer dbCounterMutex.Unlock()
+	dbCounter += 1
+	return dbCounter
+}
+
+func popFrame(counter uint64) frame {
+	iteratorStackMutex.Lock()
+	defer iteratorStackMutex.Unlock()
+	// get the item from the stack
+
+	remove := iteratorStack[counter]
+	delete(iteratorStack, counter)
+	return remove
+}
+
+// endContract is called at the end of a contract runtime to remove one item from the IteratorStack
+func endContract(counter uint64) {
+	// we pull popFrame in another function so we don't hold the mutex while cleaning up the popped frame
+	remove := popFrame(counter)
+	// free all iterators in the frame when we release it
+	for _, iter := range remove {
+		iter.Close()
+	}
+}
+
+// storeIterator will add this to the end of the latest stack and return a reference to it.
+// We start counting with 1, so the 0 value is flagged as an error. This means we must
+// remember to do idx-1 when retrieving
+func storeIterator(dbCounter uint64, it dbm.Iterator) uint64 {
+	iteratorStackMutex.Lock()
+	defer iteratorStackMutex.Unlock()
+
+	frame := append(iteratorStack[dbCounter], it)
+	iteratorStack[dbCounter] = frame
+	return uint64(len(frame))
+}
+
+// retrieveIterator will recover an iterator based on index. This ensures it will not be garbage collected.
+// We start counting with 1, in storeIterator so the 0 value is flagged as an error. This means we must
+// remember to do idx-1 when retrieving
+func retrieveIterator(dbCounter uint64, index uint64) dbm.Iterator {
+	iteratorStackMutex.Lock()
+	defer iteratorStackMutex.Unlock()
+	return iteratorStack[dbCounter][index-1]
+}

--- a/go-cosmwasm/api/iterator_test.go
+++ b/go-cosmwasm/api/iterator_test.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/CosmWasm/go-cosmwasm/types"
+)
+
+type queueData struct {
+	id      []byte
+	store   KVStore
+	api     *GoAPI
+	querier types.Querier
+}
+
+func setupQueueContractWithData(t *testing.T, cache Cache, values ...int) queueData {
+	id := createQueueContract(t, cache)
+
+	gasMeter1 := NewMockGasMeter(100000000)
+	// instantiate it with this store
+	store := NewLookup()
+	api := NewMockAPI()
+	querier := DefaultQuerier(mockContractAddr, types.Coins{types.NewCoin(100, "ATOM")})
+	params, err := json.Marshal(mockEnv(binaryAddr("creator")))
+	require.NoError(t, err)
+	msg := []byte(`{}`)
+
+	res, _, err := Instantiate(cache, id, params, msg, &gasMeter1, store, api, &querier, 100000000)
+	require.NoError(t, err)
+	requireOkResponse(t, res, 0)
+
+	for _, value := range values {
+		// push 17
+		gasMeter2 := NewMockGasMeter(100000000)
+		push := []byte(fmt.Sprintf(`{"enqueue":{"value":%d}}`, value))
+		res, _, err = Handle(cache, id, params, push, &gasMeter2, store, api, &querier, 100000000)
+		require.NoError(t, err)
+		requireOkResponse(t, res, 0)
+	}
+
+	return queueData{
+		id:      id,
+		store:   store,
+		api:     api,
+		querier: querier,
+	}
+}
+
+func setupQueueContract(t *testing.T, cache Cache) queueData {
+	return setupQueueContractWithData(t, cache, 17, 22)
+}
+
+func TestQueueIterator(t *testing.T) {
+	cache, cleanup := withCache(t)
+	defer cleanup()
+
+	setup := setupQueueContract(t, cache)
+	id, store, querier, api := setup.id, setup.store, setup.querier, setup.api
+
+	// query the sum
+	gasMeter := NewMockGasMeter(100000000)
+	query := []byte(`{"sum":{}}`)
+	data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
+	require.NoError(t, err)
+	var qres types.QueryResponse
+	err = json.Unmarshal(data, &qres)
+	require.NoError(t, err)
+	require.Nil(t, qres.Err, "%v", qres.Err)
+	require.Equal(t, string(qres.Ok), `{"sum":39}`)
+
+	// query reduce (multiple iterators at once)
+	query = []byte(`{"reducer":{}}`)
+	data, _, err = Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
+	require.NoError(t, err)
+	var reduced types.QueryResponse
+	err = json.Unmarshal(data, &reduced)
+	require.NoError(t, err)
+	require.Nil(t, reduced.Err, "%v", reduced.Err)
+	require.Equal(t, string(reduced.Ok), `{"counters":[[17,22],[22,0]]}`)
+}
+
+func TestQueueIteratorRaces(t *testing.T) {
+	cache, cleanup := withCache(t)
+	defer cleanup()
+
+	assert.Equal(t, len(iteratorStack), 0)
+
+	contract1 := setupQueueContractWithData(t, cache, 17, 22)
+	contract2 := setupQueueContractWithData(t, cache, 1, 19, 6, 35, 8)
+	contract3 := setupQueueContractWithData(t, cache, 11, 6, 2)
+
+	reduceQuery := func(t *testing.T, setup queueData, expected string) {
+		id, store, querier, api := setup.id, setup.store, setup.querier, setup.api
+
+		// query reduce (multiple iterators at once)
+		query := []byte(`{"reducer":{}}`)
+		gasMeter := NewMockGasMeter(100000000)
+		data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
+		require.NoError(t, err)
+		var reduced types.QueryResponse
+		err = json.Unmarshal(data, &reduced)
+		require.NoError(t, err)
+		require.Nil(t, reduced.Err, "%v", reduced.Err)
+		require.Equal(t, string(reduced.Ok), fmt.Sprintf(`{"counters":%s}`, expected))
+	}
+
+	// 30 concurrent batches (in go routines) to trigger any race condition
+	numBatches := 30
+
+	var wg sync.WaitGroup
+	// for each batch, query each of the 3 contracts - so the contract queries get mixed together
+	wg.Add(numBatches * 3)
+	for i := 0; i < numBatches; i++ {
+		go func() {
+			reduceQuery(t, contract1, "[[17,22],[22,0]]")
+			wg.Done()
+		}()
+		go func() {
+			reduceQuery(t, contract2, "[[1,68],[19,35],[6,62],[35,0],[8,54]]")
+			wg.Done()
+		}()
+		go func() {
+			reduceQuery(t, contract3, "[[11,0],[6,11],[2,17]]")
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// when they finish, we should have popped everything off the stack
+	assert.Equal(t, len(iteratorStack), 0)
+}

--- a/go-cosmwasm/api/lib.go
+++ b/go-cosmwasm/api/lib.go
@@ -97,7 +97,7 @@ func Instantiate(
 	params []byte,
 	msg []byte,
 	gasMeter *GasMeter,
-	store *KVStore,
+	store KVStore,
 	api *GoAPI,
 	querier *Querier,
 	gasLimit uint64,
@@ -108,11 +108,18 @@ func Instantiate(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+
+	// set up a new stack frame to handle iterators
+	counter := startContract()
+	defer endContract(counter)
+
+	dbState := buildDBState(store, counter)
+	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
+
 	res, err := C.instantiate(cache.ptr, id, p, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
@@ -127,7 +134,7 @@ func Handle(
 	params []byte,
 	msg []byte,
 	gasMeter *GasMeter,
-	store *KVStore,
+	store KVStore,
 	api *GoAPI,
 	querier *Querier,
 	gasLimit uint64,
@@ -138,11 +145,18 @@ func Handle(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+
+	// set up a new stack frame to handle iterators
+	counter := startContract()
+	defer endContract(counter)
+
+	dbState := buildDBState(store, counter)
+	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
+
 	res, err := C.handle(cache.ptr, id, p, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
@@ -157,7 +171,7 @@ func Migrate(
 	params []byte,
 	msg []byte,
 	gasMeter *GasMeter,
-	store *KVStore,
+	store KVStore,
 	api *GoAPI,
 	querier *Querier,
 	gasLimit uint64,
@@ -168,11 +182,18 @@ func Migrate(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+
+	// set up a new stack frame to handle iterators
+	counter := startContract()
+	defer endContract(counter)
+
+	dbState := buildDBState(store, counter)
+	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
+
 	res, err := C.migrate(cache.ptr, id, p, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
@@ -186,7 +207,7 @@ func Query(
 	code_id []byte,
 	msg []byte,
 	gasMeter *GasMeter,
-	store *KVStore,
+	store KVStore,
 	api *GoAPI,
 	querier *Querier,
 	gasLimit uint64,
@@ -195,11 +216,18 @@ func Query(
 	defer freeAfterSend(id)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+
+	// set up a new stack frame to handle iterators
+	counter := startContract()
+	defer endContract(counter)
+
+	dbState := buildDBState(store, counter)
+	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
+
 	res, err := C.query(cache.ptr, id, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.

--- a/go-cosmwasm/api/lib_test.go
+++ b/go-cosmwasm/api/lib_test.go
@@ -114,12 +114,12 @@ func TestInstantiate(t *testing.T) {
 	require.NoError(t, err)
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
 
-	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter, &store, api, &querier, 100000000)
+	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 	assert.Equal(t, uint64(0x11f57), cost)
 
-	var resp types.CosmosResponse
+	var resp types.InitResult
 	err = json.Unmarshal(res, &resp)
 	require.NoError(t, err)
 	require.Nil(t, resp.Err)
@@ -143,7 +143,7 @@ func TestHandle(t *testing.T) {
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
 
 	start := time.Now()
-	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter1, &store, api, &querier, 100000000)
+	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter1, store, api, &querier, 100000000)
 	diff := time.Now().Sub(start)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
@@ -155,14 +155,14 @@ func TestHandle(t *testing.T) {
 	params, err = json.Marshal(mockEnv(binaryAddr("fred")))
 	require.NoError(t, err)
 	start = time.Now()
-	res, cost, err = Handle(cache, id, params, []byte(`{"release":{}}`), &gasMeter2, &store, api, &querier, 100000000)
+	res, cost, err = Handle(cache, id, params, []byte(`{"release":{}}`), &gasMeter2, store, api, &querier, 100000000)
 	diff = time.Now().Sub(start)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0x1c135), cost)
 	fmt.Printf("Time (%d gas): %s\n", cost, diff)
 
 	// make sure it read the balance properly and we got 250 atoms
-	var resp types.CosmosResponse
+	var resp types.HandleResult
 	err = json.Unmarshal(res, &resp)
 	require.NoError(t, err)
 	require.Nil(t, resp.Err)
@@ -191,13 +191,13 @@ func TestMigrate(t *testing.T) {
 	require.NoError(t, err)
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
 
-	res, _, err := Instantiate(cache, id, params, msg, &gasMeter, &store, api, &querier, 100000000)
+	res, _, err := Instantiate(cache, id, params, msg, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 
 	// verifier is fred
 	query := []byte(`{"verifier":{}}`)
-	data, _, err := Query(cache, id, query, &gasMeter, &store, api, &querier, 100000000)
+	data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres types.QueryResponse
 	err = json.Unmarshal(data, &qres)
@@ -209,11 +209,11 @@ func TestMigrate(t *testing.T) {
 	// we use the same code blob as we are testing hackatom self-migration
 	params, err = json.Marshal(mockEnv(binaryAddr("fred")))
 	require.NoError(t, err)
-	res, _, err = Migrate(cache, id, params, []byte(`{"verifier":"alice"}`), &gasMeter, &store, api, &querier, 100000000)
+	res, _, err = Migrate(cache, id, params, []byte(`{"verifier":"alice"}`), &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 
 	// should update verifier to alice
-	data, _, err = Query(cache, id, query, &gasMeter, &store, api, &querier, 100000000)
+	data, _, err = Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres2 types.QueryResponse
 	err = json.Unmarshal(data, &qres2)
@@ -235,7 +235,7 @@ func TestMultipleInstances(t *testing.T) {
 	params, err := json.Marshal(mockEnv(binaryAddr("regen")))
 	require.NoError(t, err)
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
-	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter1, &store1, api, &querier, 100000000)
+	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter1, store1, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 	assert.Equal(t, uint64(0x11f57), cost)
@@ -246,7 +246,7 @@ func TestMultipleInstances(t *testing.T) {
 	params, err = json.Marshal(mockEnv(binaryAddr("chorus")))
 	require.NoError(t, err)
 	msg = []byte(`{"verifier": "mary", "beneficiary": "sue"}`)
-	res, cost, err = Instantiate(cache, id, params, msg, &gasMeter2, &store2, api, &querier, 100000000)
+	res, cost, err = Instantiate(cache, id, params, msg, &gasMeter2, store2, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 	assert.Equal(t, uint64(0x11f57), cost)
@@ -277,7 +277,7 @@ func TestMultipleInstances(t *testing.T) {
 }
 
 func requireOkResponse(t *testing.T, res []byte, expectedMsgs int) {
-	var resp types.CosmosResponse
+	var resp types.HandleResult
 	err := json.Unmarshal(res, &resp)
 	require.NoError(t, err)
 	require.Nil(t, resp.Err, "%v", resp.Err)
@@ -305,15 +305,15 @@ func createContract(t *testing.T, cache Cache, wasmFile string) []byte {
 }
 
 // exec runs the handle tx with the given signer
-func exec(t *testing.T, cache Cache, id []byte, signer string, store KVStore, api *GoAPI, querier Querier, gas uint64) types.CosmosResponse {
+func exec(t *testing.T, cache Cache, id []byte, signer string, store KVStore, api *GoAPI, querier Querier, gas uint64) types.HandleResult {
 	gasMeter := NewMockGasMeter(100000000)
 	params, err := json.Marshal(mockEnv(binaryAddr(signer)))
 	require.NoError(t, err)
-	res, cost, err := Handle(cache, id, params, []byte(`{"release":{}}`), &gasMeter, &store, api, &querier, 100000000)
+	res, cost, err := Handle(cache, id, params, []byte(`{"release":{}}`), &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	assert.Equal(t, gas, cost)
 
-	var resp types.CosmosResponse
+	var resp types.HandleResult
 	err = json.Unmarshal(res, &resp)
 	require.NoError(t, err)
 	return resp
@@ -332,13 +332,13 @@ func TestQuery(t *testing.T) {
 	params, err := json.Marshal(mockEnv(binaryAddr("creator")))
 	require.NoError(t, err)
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
-	_, _, err = Instantiate(cache, id, params, msg, &gasMeter1, &store, api, &querier, 100000000)
+	_, _, err = Instantiate(cache, id, params, msg, &gasMeter1, store, api, &querier, 100000000)
 	require.NoError(t, err)
 
 	// invalid query
 	gasMeter2 := NewMockGasMeter(100000000)
 	query := []byte(`{"Raw":{"val":"config"}}`)
-	data, _, err := Query(cache, id, query, &gasMeter2, &store, api, &querier, 100000000)
+	data, _, err := Query(cache, id, query, &gasMeter2, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var badResp types.QueryResponse
 	err = json.Unmarshal(data, &badResp)
@@ -353,67 +353,13 @@ func TestQuery(t *testing.T) {
 	// make a valid query
 	gasMeter3 := NewMockGasMeter(100000000)
 	query = []byte(`{"verifier":{}}`)
-	data, _, err = Query(cache, id, query, &gasMeter3, &store, api, &querier, 100000000)
+	data, _, err = Query(cache, id, query, &gasMeter3, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres types.QueryResponse
 	err = json.Unmarshal(data, &qres)
 	require.NoError(t, err)
 	require.Nil(t, qres.Err, "%v", qres.Err)
 	require.Equal(t, string(qres.Ok), `{"verifier":"fred"}`)
-}
-
-func TestQueueIterator(t *testing.T) {
-	cache, cleanup := withCache(t)
-	defer cleanup()
-	id := createQueueContract(t, cache)
-
-	gasMeter1 := NewMockGasMeter(100000000)
-	// instantiate it with this store
-	store := NewLookup()
-	api := NewMockAPI()
-	querier := DefaultQuerier(mockContractAddr, types.Coins{types.NewCoin(100, "ATOM")})
-	params, err := json.Marshal(mockEnv(binaryAddr("creator")))
-	require.NoError(t, err)
-	msg := []byte(`{}`)
-
-	res, _, err := Instantiate(cache, id, params, msg, &gasMeter1, &store, api, &querier, 100000000)
-	require.NoError(t, err)
-	requireOkResponse(t, res, 0)
-
-	// push 17
-	gasMeter2 := NewMockGasMeter(100000000)
-	push := []byte(`{"enqueue":{"value":17}}`)
-	res, _, err = Handle(cache, id, params, push, &gasMeter2, &store, api, &querier, 100000000)
-	require.NoError(t, err)
-	requireOkResponse(t, res, 0)
-	// push 22
-	gasMeter3 := NewMockGasMeter(100000000)
-	push = []byte(`{"enqueue":{"value":22}}`)
-	res, _, err = Handle(cache, id, params, push, &gasMeter3, &store, api, &querier, 100000000)
-	require.NoError(t, err)
-	requireOkResponse(t, res, 0)
-
-	// query the sum
-	gasMeter4 := NewMockGasMeter(100000000)
-	query := []byte(`{"sum":{}}`)
-	data, _, err := Query(cache, id, query, &gasMeter4, &store, api, &querier, 100000000)
-	require.NoError(t, err)
-	var qres types.QueryResponse
-	err = json.Unmarshal(data, &qres)
-	require.NoError(t, err)
-	require.Nil(t, qres.Err, "%v", qres.Err)
-	require.Equal(t, string(qres.Ok), `{"sum":39}`)
-
-	// query reduce (multiple iterators at once)
-	gasMeter5 := NewMockGasMeter(100000000)
-	query = []byte(`{"reducer":{}}`)
-	data, _, err = Query(cache, id, query, &gasMeter5, &store, api, &querier, 100000000)
-	require.NoError(t, err)
-	var reduced types.QueryResponse
-	err = json.Unmarshal(data, &reduced)
-	require.NoError(t, err)
-	require.Nil(t, reduced.Err, "%v", reduced.Err)
-	require.Equal(t, string(reduced.Ok), `{"counters":[[17,22],[22,0]]}`)
 }
 
 func TestHackatomQuerier(t *testing.T) {
@@ -431,7 +377,7 @@ func TestHackatomQuerier(t *testing.T) {
 	// make a valid query to the other address
 	query := []byte(`{"other_balance":{"address":"foobar"}}`)
 	// TODO The query happens before the contract is initialized. How is this legal?
-	data, _, err := Query(cache, id, query, &gasMeter, &store, api, &querier, 100000000)
+	data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres types.QueryResponse
 	err = json.Unmarshal(data, &qres)
@@ -460,7 +406,7 @@ func TestCustomReflectQuerier(t *testing.T) {
 
 	// make a valid query to the other address
 	query := []byte(`{"reflect_custom":{"text":"small Frys :)"}}`)
-	data, _, err := Query(cache, id, query, &gasMeter, &store, api, &querier, 100000000)
+	data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres types.QueryResponse
 	err = json.Unmarshal(data, &qres)

--- a/go-cosmwasm/types/msg.go
+++ b/go-cosmwasm/types/msg.go
@@ -6,14 +6,44 @@ import (
 
 //------- Results / Msgs -------------
 
-// CosmosResponse is the raw response from the init / handle calls
-type CosmosResponse struct {
-	Ok  *Result   `json:"Ok,omitempty"`
-	Err *StdError `json:"Err,omitempty"`
+// HandleResult is the raw response from the handle call
+type HandleResult struct {
+	Ok  *HandleResponse `json:"Ok,omitempty"`
+	Err *StdError       `json:"Err,omitempty"`
 }
 
-// Result defines the return value on a successful
-type Result struct {
+// HandleResponse defines the return value on a successful handle
+type HandleResponse struct {
+	// Messages comes directly from the contract and is it's request for action
+	Messages []CosmosMsg `json:"messages"`
+	// base64-encoded bytes to return as ABCI.Data field
+	Data string `json:"data"`
+	// log message to return over abci interface
+	Log []LogAttribute `json:"log"`
+}
+
+// InitResult is the raw response from the handle call
+type InitResult struct {
+	Ok  *InitResponse `json:"Ok,omitempty"`
+	Err *StdError     `json:"Err,omitempty"`
+}
+
+// InitResponse defines the return value on a successful handle
+type InitResponse struct {
+	// Messages comes directly from the contract and is it's request for action
+	Messages []CosmosMsg `json:"messages"`
+	// log message to return over abci interface
+	Log []LogAttribute `json:"log"`
+}
+
+// MigrateResult is the raw response from the handle call
+type MigrateResult struct {
+	Ok  *MigrateResponse `json:"Ok,omitempty"`
+	Err *StdError        `json:"Err,omitempty"`
+}
+
+// MigrateResponse defines the return value on a successful handle
+type MigrateResponse struct {
 	// Messages comes directly from the contract and is it's request for action
 	Messages []CosmosMsg `json:"messages"`
 	// base64-encoded bytes to return as ABCI.Data field

--- a/go-cosmwasm/types/stderror.go
+++ b/go-cosmwasm/types/stderror.go
@@ -12,7 +12,6 @@ type StdError struct {
 	InvalidBase64 *InvalidBase64 `json:"invalid_base64,omitempty"`
 	InvalidUtf8   *InvalidUtf8   `json:"invalid_utf8,omitempty"`
 	NotFound      *NotFound      `json:"not_found,omitempty"`
-	NullPointer   *NullPointer   `json:"null_pointer,omitempty"`
 	ParseErr      *ParseErr      `json:"parse_err,omitempty"`
 	SerializeErr  *SerializeErr  `json:"serialize_err,omitempty"`
 	Unauthorized  *Unauthorized  `json:"unauthorized,omitempty"`
@@ -25,7 +24,6 @@ var (
 	_ error = InvalidBase64{}
 	_ error = InvalidUtf8{}
 	_ error = NotFound{}
-	_ error = NullPointer{}
 	_ error = ParseErr{}
 	_ error = SerializeErr{}
 	_ error = Unauthorized{}
@@ -42,8 +40,6 @@ func (a StdError) Error() string {
 		return a.InvalidUtf8.Error()
 	case a.NotFound != nil:
 		return a.NotFound.Error()
-	case a.NullPointer != nil:
-		return a.NullPointer.Error()
 	case a.ParseErr != nil:
 		return a.ParseErr.Error()
 	case a.SerializeErr != nil:
@@ -87,12 +83,6 @@ type NotFound struct {
 
 func (e NotFound) Error() string {
 	return fmt.Sprintf("not found: %s", e.Kind)
-}
-
-type NullPointer struct{}
-
-func (e NullPointer) Error() string {
-	return "null pointer"
 }
 
 type ParseErr struct {
@@ -159,10 +149,6 @@ func ToStdError(err error) *StdError {
 		return &StdError{NotFound: &t}
 	case *NotFound:
 		return &StdError{NotFound: t}
-	case NullPointer:
-		return &StdError{NullPointer: &t}
-	case *NullPointer:
-		return &StdError{NullPointer: t}
 	case ParseErr:
 		return &StdError{ParseErr: &t}
 	case *ParseErr:


### PR DESCRIPTION
This PR copies the contents of the `de9dfbb` commit from `enigmampc/go-cosmwasm`.
It merges the latest commit on the `cosmwasm-0.9` branch in this repo (fb608de8) with the latest commit on the `master` branch of `CosmWasm/go-cosmwasm` (`3ae26f7`, also tag `v0.9.0-alpha2`).

The new content includes: (bold is interesting)
* Split CosmosResponse into Init/Handle/Migrate-Result
* **fixed memory bug in Go related to storage iterators**

To the reviewers, please try to `git merge origin/upstream-go-cosmwasm-de9dfbb` this branch to your branches and let me know if you got any conflicts. If you don't then please approve this PR. I will merge it once i have all 3 approvals.
Of course, you don't have to keep that merge commit, and instead reset to your original commit, and merge later.