### PR TITLE
Node auth error messages

### DIFF
--- a/cosmwasm/packages/enclave-ffi-types/src/lib.rs
+++ b/cosmwasm/packages/enclave-ffi-types/src/lib.rs
@@ -4,8 +4,8 @@
 mod types;
 
 pub use types::{
-    Ctx, EnclaveBuffer, EnclaveError, HandleResult, InitResult, OcallReturn, QueryResult,
-    UntrustedVmError, UserSpaceBuffer,
+    Ctx, EnclaveBuffer, EnclaveError, HandleResult, InitResult, NodeAuthResult, OcallReturn,
+    QueryResult, UntrustedVmError, UserSpaceBuffer,
 };
 
 pub const ENCRYPTED_SEED_SIZE: usize = 48;

--- a/cosmwasm/packages/enclave-ffi-types/src/types.rs
+++ b/cosmwasm/packages/enclave-ffi-types/src/types.rs
@@ -92,6 +92,28 @@ pub enum EnclaveError {
     Unknown,
 }
 
+/// This type represents the possible error conditions that can be encountered in the
+/// enclave while authenticating a new node in the network.
+/// cbindgen:prefix-with-name
+#[repr(C)]
+#[derive(Debug, Display, PartialEq, Eq)]
+pub enum NodeAuthResult {
+    Success,
+    #[display(fmt = "Enclave received invalid inputs")]
+    InvalidInput,
+    #[display(fmt = "The provided certificate was invalid")]
+    InvalidCert,
+    #[display(fmt = "Writing to file system from the enclave failed")]
+    CantWriteToStorage,
+    #[display(fmt = "The public key in the certificate appears to be malformed")]
+    MalformedPublicKey,
+    #[display(fmt = "Encrypting the seed failed")]
+    SeedEncryptionFailed,
+    EnclaveFailure,
+    #[display(fmt = "Enclave panicked :( please file a bug report!")]
+    Panic,
+}
+
 /// This type holds a pointer to a VmError that is boxed on the untrusted side
 // `VmError` is the standard error type for the `cosmwasm-sgx-vm` layer.
 // During an ocall, we call into the original implementation of `db_read`, `db_write`, and `db_remove`.

--- a/cosmwasm/packages/sgx-vm/src/attestation.rs
+++ b/cosmwasm/packages/sgx-vm/src/attestation.rs
@@ -7,7 +7,7 @@ use log::*;
 use sgx_types::*;
 use sgx_types::{sgx_status_t, SgxResult};
 
-use enclave_ffi_types::ENCRYPTED_SEED_SIZE;
+use enclave_ffi_types::{NodeAuthResult, ENCRYPTED_SEED_SIZE};
 
 use crate::enclave::get_enclave;
 
@@ -18,7 +18,7 @@ extern "C" {
     ) -> sgx_status_t;
     pub fn ecall_authenticate_new_node(
         eid: sgx_enclave_id_t,
-        retval: *mut sgx_status_t,
+        retval: *mut NodeAuthResult,
         cert: *const u8,
         cert_len: u32,
         seed: &mut [u8; ENCRYPTED_SEED_SIZE],
@@ -122,7 +122,7 @@ pub extern "C" fn ocall_get_update_info(
     unsafe { sgx_report_attestation_status(platform_blob, enclave_trusted, update_info) }
 }
 
-pub fn create_attestation_report_u() -> SgxResult<sgx_status_t> {
+pub fn create_attestation_report_u() -> SgxResult<()> {
     info!("Hello from just before initializing - create_attestation_report_u");
     let enclave = get_enclave()?;
     info!("Hello from just after initializing - create_attestation_report_u");
@@ -140,17 +140,19 @@ pub fn create_attestation_report_u() -> SgxResult<sgx_status_t> {
         return Err(retval);
     }
 
-    Ok(sgx_status_t::SGX_SUCCESS)
+    Ok(())
 }
 
-pub fn untrusted_get_encrypted_seed(cert: &[u8]) -> SgxResult<[u8; ENCRYPTED_SEED_SIZE]> {
+pub fn untrusted_get_encrypted_seed(
+    cert: &[u8],
+) -> SgxResult<Result<[u8; ENCRYPTED_SEED_SIZE], NodeAuthResult>> {
     info!("Hello from just before initializing - untrusted_get_encrypted_seed");
     let enclave = get_enclave()?;
     info!("Hello from just after initializing - untrusted_get_encrypted_seed");
 
     info!("Entered produce report");
     let eid = enclave.geteid();
-    let mut retval = sgx_status_t::SGX_SUCCESS;
+    let mut retval = NodeAuthResult::Success;
     let mut seed = [0u8; ENCRYPTED_SEED_SIZE];
     let status = unsafe {
         ecall_authenticate_new_node(
@@ -166,8 +168,8 @@ pub fn untrusted_get_encrypted_seed(cert: &[u8]) -> SgxResult<[u8; ENCRYPTED_SEE
         return Err(status);
     }
 
-    if retval != sgx_status_t::SGX_SUCCESS {
-        return Err(retval);
+    if retval != NodeAuthResult::Success {
+        return Ok(Err(retval));
     }
 
     if seed.is_empty() {
@@ -175,7 +177,7 @@ pub fn untrusted_get_encrypted_seed(cert: &[u8]) -> SgxResult<[u8; ENCRYPTED_SEE
         return Err(sgx_status_t::SGX_ERROR_UNEXPECTED);
     }
 
-    Ok(seed)
+    Ok(Ok(seed))
 }
 
 #[cfg(test)]

--- a/cosmwasm/packages/sgx-vm/src/seed.rs
+++ b/cosmwasm/packages/sgx-vm/src/seed.rs
@@ -27,7 +27,7 @@ extern "C" {
     ) -> sgx_status_t;
 }
 
-pub fn untrusted_init_node(master_cert: &[u8], encrypted_seed: &[u8]) -> SgxResult<sgx_status_t> {
+pub fn untrusted_init_node(master_cert: &[u8], encrypted_seed: &[u8]) -> SgxResult<()> {
     info!("Hello from just before initializing - init_node");
     let enclave = get_enclave()?;
     info!("Hello from just after initializing - init_node");
@@ -54,7 +54,7 @@ pub fn untrusted_init_node(master_cert: &[u8], encrypted_seed: &[u8]) -> SgxResu
         return Err(ret);
     }
 
-    Ok(sgx_status_t::SGX_SUCCESS)
+    Ok(())
 }
 
 pub fn untrusted_key_gen() -> SgxResult<[u8; 32]> {

--- a/cosmwasm/packages/wasmi-runtime/Enclave.edl
+++ b/cosmwasm/packages/wasmi-runtime/Enclave.edl
@@ -29,7 +29,7 @@ enclave {
 
         public sgx_status_t ecall_get_attestation_report();
 
-        public sgx_status_t ecall_authenticate_new_node(
+        public NodeAuthResult ecall_authenticate_new_node(
             [in, count=cert_len] const uint8_t* cert,
             uintptr_t cert_len,
             [out, count=48] uint8_t* seed

--- a/cosmwasm/packages/wasmi-runtime/src/registration/cert.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/cert.rs
@@ -300,10 +300,7 @@ pub fn verify_ra_cert(cert_der: &[u8]) -> SgxResult<Vec<u8>> {
 
     // 2. Verify quote status (mandatory field)
 
-    match verify_quote_status(report.sgx_quote_status) {
-        Ok(_) => (),
-        Err(e) => return Err(e),
-    }
+    verify_quote_status(report.sgx_quote_status)?;
 
     // verify certificate
     match SIGNING_METHOD {

--- a/go-cosmwasm/src/error/rust.rs
+++ b/go-cosmwasm/src/error/rust.rs
@@ -35,6 +35,12 @@ pub enum Error {
         #[cfg(feature = "backtraces")]
         backtrace: snafu::Backtrace,
     },
+    #[snafu(display("Error calling the enclave: {}", msg))]
+    EnclaveErr {
+        msg: String,
+        #[cfg(feature = "backtraces")]
+        backtrace: snafu::Backtrace,
+    },
 }
 
 impl Error {
@@ -55,6 +61,13 @@ impl Error {
 
     pub fn vm_err<S: ToString>(msg: S) -> Self {
         VmErr {
+            msg: msg.to_string(),
+        }
+        .build()
+    }
+
+    pub fn enclave_err<S: ToString>(msg: S) -> Self {
+        EnclaveErr {
             msg: msg.to_string(),
         }
         .build()


### PR DESCRIPTION
This PR makes errors in node authentication display more useful errors for users that encounter them.
closes #376 
To reviewer: The technique shown here to generate nicer error messages can and should be applied to `EnclaveError`.