### PR TITLE
secretjs@0.9.11 - Fix REST path used for smart query

### DIFF
--- a/cosmwasm-js/packages/sdk/package.json
+++ b/cosmwasm-js/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretjs",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "CosmWasm SDK + Encryption for the Secret Network",
   "author": "Ethan Frey <ethanfrey@users.noreply.github.com>",
   "contributors": [

--- a/cosmwasm-js/packages/sdk/src/restclient.ts
+++ b/cosmwasm-js/packages/sdk/src/restclient.ts
@@ -468,7 +468,7 @@ export class RestClient {
     const nonce = encrypted.slice(0, 32);
 
     const encoded = Encoding.toHex(Encoding.toUtf8(Encoding.toBase64(encrypted)));
-    const path = `/wasm/contract/${address}/smart/${encoded}?encoding=hex`;
+    const path = `/wasm/contract/${address}/query/${encoded}?encoding=hex`;
     let responseData;
     try {
       responseData = (await this.get(path)) as WasmResponse<SmartQueryResponse>;


### PR DESCRIPTION
This PR fixes the REST path that is being used for "smart" queries. See #387.