### PR TITLE
DNS like usage of label

### DIFF
--- a/x/compute/client/cli/tx.go
+++ b/x/compute/client/cli/tx.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"fmt"
+	"github.com/enigmampc/SecretNetwork/x/compute/internal/keeper"
 	"io/ioutil"
 	"strconv"
 
@@ -132,7 +133,12 @@ func InstantiateContractCmd(cdc *codec.Codec) *cobra.Command {
 
 			label := viper.GetString(flagLabel)
 			if label == "" {
-				return fmt.Errorf("Label is required on all contracts")
+				return fmt.Errorf("label is required on all contracts")
+			}
+			route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, keeper.QueryContractAddress, label)
+			res, _, err := cliCtx.Query(route)
+			if res != nil {
+				return fmt.Errorf("label already exists. You must choose a unique label for your contract instance")
 			}
 
 			wasmCtx := wasmUtils.WASMContext{CLIContext: cliCtx}
@@ -174,18 +180,39 @@ func InstantiateContractCmd(cdc *codec.Codec) *cobra.Command {
 // ExecuteContractCmd will instantiate a contract from previously uploaded code.
 func ExecuteContractCmd(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "execute [contract_addr_bech32] [json_encoded_send_args]",
+		Use:   "execute [optional: contract_addr_bech32] [json_encoded_send_args]",
 		Short: "Execute a command on a wasm contract",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContextWithInput(inBuf).WithCodec(cdc)
 
-			// get the id of the code to instantiate
-			contractAddr, err := sdk.AccAddressFromBech32(args[0])
-			if err != nil {
-				return err
+			var contractAddr = sdk.AccAddress{}
+			var execMsg []byte
+			if len(args) == 1 {
+				label := viper.GetString(flagLabel)
+				if label == "" {
+					return fmt.Errorf("Label or bech32 contract address is required")
+				}
+
+				route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, keeper.QueryContractAddress, label)
+				res, _, err := cliCtx.Query(route)
+				if err != nil {
+					return err
+				}
+
+				contractAddr = res
+				execMsg = []byte(args[0])
+			} else {
+				// get the id of the code to instantiate
+				res, err := sdk.AccAddressFromBech32(args[0])
+				if err != nil {
+					return err
+				}
+
+				contractAddr = res
+				execMsg = []byte(args[1])
 			}
 
 			amounstStr := viper.GetString(flagAmount)
@@ -196,7 +223,6 @@ func ExecuteContractCmd(cdc *codec.Codec) *cobra.Command {
 
 			wasmCtx := wasmUtils.WASMContext{CLIContext: cliCtx}
 
-			execMsg := []byte(args[1])
 			execMsg, err = wasmCtx.Encrypt(execMsg)
 			if err != nil {
 				return err
@@ -214,5 +240,6 @@ func ExecuteContractCmd(cdc *codec.Codec) *cobra.Command {
 	}
 
 	cmd.Flags().String(flagAmount, "", "Coins to send to the contract along with command")
+	cmd.Flags().String(flagLabel, "", "A human-readable name for this contract in lists")
 	return cmd
 }

--- a/x/compute/internal/keeper/keeper.go
+++ b/x/compute/internal/keeper/keeper.go
@@ -92,6 +92,14 @@ func (k Keeper) Create(ctx sdk.Context, creator sdk.AccAddress, wasmCode []byte,
 // Instantiate creates an instance of a WASM contract
 func (k Keeper) Instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.AccAddress, initMsg []byte, label string, deposit sdk.Coins) (sdk.AccAddress, error) {
 	// create contract address
+
+	store := ctx.KVStore(k.storeKey)
+	existingAddress := store.Get(types.GetContractLabelPrefix(label))
+
+	if existingAddress != nil {
+		return nil, sdkerrors.Wrap(types.ErrAccountExists, label)
+	}
+
 	contractAddress := k.generateContractAddress(ctx, codeID)
 	existingAcct := k.accountKeeper.GetAccount(ctx, contractAddress)
 	if existingAcct != nil {
@@ -112,11 +120,12 @@ func (k Keeper) Instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.A
 	}
 
 	// get contact info
-	store := ctx.KVStore(k.storeKey)
+
 	bz := store.Get(types.GetCodeKey(codeID))
 	if bz == nil {
 		return nil, sdkerrors.Wrap(types.ErrNotFound, "contract")
 	}
+
 	var codeInfo types.CodeInfo
 	k.cdc.MustUnmarshalBinaryBare(bz, &codeInfo)
 
@@ -159,6 +168,8 @@ func (k Keeper) Instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.A
 	fmt.Printf("Storing key: %s for account %s", key, contractAddress)
 
 	store.Set(types.GetContractEnclaveKey(contractAddress), key)
+
+	store.Set(types.GetContractLabelPrefix(label), contractAddress)
 
 	return contractAddress, nil
 }
@@ -358,6 +369,14 @@ func (k Keeper) contractInstance(ctx sdk.Context, contractAddress sdk.AccAddress
 	prefixStoreKey := types.GetContractStorePrefixKey(contractAddress)
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), prefixStoreKey)
 	return codeInfo, prefixStore, nil
+}
+
+func (k Keeper) GetContractAddress(ctx sdk.Context, label string) sdk.AccAddress {
+	store := ctx.KVStore(k.storeKey)
+
+	contractAddress := store.Get(types.GetContractLabelPrefix(label))
+
+	return contractAddress
 }
 
 func (k Keeper) GetContractInfo(ctx sdk.Context, contractAddress sdk.AccAddress) *types.ContractInfo {

--- a/x/compute/internal/keeper/keeper_test.go
+++ b/x/compute/internal/keeper/keeper_test.go
@@ -237,7 +237,7 @@ func TestInstantiate(t *testing.T) {
 	require.Equal(t, "secret18vd8fpwxzck93qlwghaj6arh4p7c5n8978vsyg", addr.String())
 
 	gasAfter := ctx.GasMeter().GasConsumed()
-	require.Equal(t, uint64(34133), gasAfter-gasBefore)
+	require.Equal(t, uint64(37733), gasAfter-gasBefore)
 
 	// ensure it is stored properly
 	info := keeper.GetContractInfo(ctx, addr)

--- a/x/compute/internal/keeper/keeper_test.go
+++ b/x/compute/internal/keeper/keeper_test.go
@@ -246,6 +246,10 @@ func TestInstantiate(t *testing.T) {
 	require.Equal(t, info.CodeID, contractID)
 	require.Equal(t, info.InitMsg, initMsgBz)
 	require.Equal(t, info.Label, "demo contract 1")
+
+	// test that creating again with the same label will fail
+	addr, err = keeper.Instantiate(ctx, contractID, creator, nil, initMsgBz, "demo contract 1", nil)
+	require.Error(t, err)
 }
 
 func TestInstantiateWithNonExistingCodeID(t *testing.T) {

--- a/x/compute/internal/keeper/querier.go
+++ b/x/compute/internal/keeper/querier.go
@@ -19,6 +19,7 @@ const (
 	QueryGetContractState   = "query"
 	QueryGetCode            = "code"
 	QueryListCode           = "list-code"
+	QueryContractAddress    = "label"
 )
 
 // ContractInfoWithAddress adds the address (key) to the ContractInfo representation
@@ -45,6 +46,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return queryCode(ctx, path[1], req, keeper)
 		case QueryListCode:
 			return queryCodeList(ctx, req, keeper)
+		case QueryContractAddress:
+			return queryContractAddress(ctx, path[1], req, keeper)
 		default:
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "unknown data query endpoint")
 		}
@@ -191,4 +194,13 @@ func queryCodeList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byt
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 	return bz, nil
+}
+
+func queryContractAddress(ctx sdk.Context, label string, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+	res := keeper.GetContractAddress(ctx, label)
+	if res == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownAddress, label)
+	}
+
+	return res, nil
 }

--- a/x/compute/internal/keeper/querier_test.go
+++ b/x/compute/internal/keeper/querier_test.go
@@ -69,7 +69,7 @@ func TestQueryContractLabel(t *testing.T) {
 		"query label exists": {
 			srcPath:     []string{QueryContractAddress, label},
 			srcReq:      abci.RequestQuery{},
-			expSmartRes: fmt.Sprintf(`Label is in use by contract address:  %s`, addr.String()),
+			expSmartRes: string(addr),
 		},
 	}
 

--- a/x/compute/internal/keeper/querier_test.go
+++ b/x/compute/internal/keeper/querier_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestQueryContractLabel(t *testing.T) {
-	t.SkipNow() // cannot interact directly with state
 
 	tempDir, err := ioutil.TempDir("", "wasm")
 	require.NoError(t, err)

--- a/x/compute/internal/keeper/querier_test.go
+++ b/x/compute/internal/keeper/querier_test.go
@@ -67,7 +67,7 @@ func TestQueryContractLabel(t *testing.T) {
 			expErr:  sdkErrors.ErrUnknownAddress,
 		},
 		"query label exists": {
-			srcPath:     []string{QueryGetContractState, label},
+			srcPath:     []string{QueryContractAddress, label},
 			srcReq:      abci.RequestQuery{},
 			expSmartRes: fmt.Sprintf(`Label is in use by contract address:  %s`, addr.String()),
 		},

--- a/x/compute/internal/keeper/querier_test.go
+++ b/x/compute/internal/keeper/querier_test.go
@@ -14,6 +14,93 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
+func TestQueryContractLabel(t *testing.T) {
+	t.SkipNow() // cannot interact directly with state
+
+	tempDir, err := ioutil.TempDir("", "wasm")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	ctx, keepers := CreateTestInput(t, false, tempDir, SupportedFeatures, nil, nil)
+	accKeeper, keeper := keepers.AccountKeeper, keepers.WasmKeeper
+
+	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
+	topUp := sdk.NewCoins(sdk.NewInt64Coin("denom", 5000))
+	creator := createFakeFundedAccount(ctx, accKeeper, deposit.Add(deposit...))
+	anyAddr := createFakeFundedAccount(ctx, accKeeper, topUp)
+
+	wasmCode, err := ioutil.ReadFile("./testdata/contract.wasm")
+	require.NoError(t, err)
+
+	contractID, err := keeper.Create(ctx, creator, wasmCode, "", "")
+	require.NoError(t, err)
+
+	_, _, bob := keyPubAddr()
+	initMsg := InitMsg{
+		Verifier:    anyAddr,
+		Beneficiary: bob,
+	}
+	initMsgBz, err := json.Marshal(initMsg)
+	require.NoError(t, err)
+
+	initMsgBz, err = wasmCtx.Encrypt(initMsgBz)
+	require.NoError(t, err)
+
+	label := "banana"
+	addr, err := keeper.Instantiate(ctx, contractID, creator, nil, initMsgBz, label, deposit)
+	require.NoError(t, err)
+
+	// this gets us full error, not redacted sdk.Error
+	q := NewQuerier(keeper)
+	specs := map[string]struct {
+		srcPath []string
+		srcReq  abci.RequestQuery
+		// smart queries return raw bytes from contract not []types.Model
+		// if this is set, then we just compare - (should be json encoded string)
+		expSmartRes string
+		// if success and expSmartRes is not set, we parse into []types.Model and compare
+		expModelLen      int
+		expModelContains []types.Model
+		expErr           *sdkErrors.Error
+	}{
+		"query label available": {
+			srcPath: []string{QueryContractAddress, "banananana"},
+			srcReq:  abci.RequestQuery{},
+			expErr:  sdkErrors.ErrUnknownAddress,
+		},
+		"query label exists": {
+			srcPath:     []string{QueryGetContractState, label},
+			srcReq:      abci.RequestQuery{},
+			expSmartRes: fmt.Sprintf(`Label is in use by contract address:  %s`, addr.String()),
+		},
+	}
+
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			binResult, err := q(ctx, spec.srcPath, spec.srcReq)
+			// require.True(t, spec.expErr.Is(err), "unexpected error")
+			require.True(t, spec.expErr.Is(err), err)
+
+			// if smart query, check custom response
+			if spec.expSmartRes != "" {
+				require.Equal(t, spec.expSmartRes, string(binResult))
+				return
+			}
+
+			// otherwise, check returned models
+			var r []types.Model
+			if spec.expErr == nil {
+				require.NoError(t, json.Unmarshal(binResult, &r))
+				require.NotNil(t, r)
+			}
+			require.Len(t, r, spec.expModelLen)
+			// and in result set
+			for _, v := range spec.expModelContains {
+				require.Contains(t, r, v)
+			}
+		})
+	}
+}
+
 func TestQueryContractState(t *testing.T) {
 	t.SkipNow() // cannot interact directly with state
 

--- a/x/compute/internal/keeper/secret_contracts_test.go
+++ b/x/compute/internal/keeper/secret_contracts_test.go
@@ -199,7 +199,8 @@ func initHelper(t *testing.T, keeper Keeper, ctx sdk.Context, codeID uint64, cre
 		log.NewNopLogger(),
 	).WithGasMeter(sdk.NewGasMeter(gas))
 
-	contractAddress, err := keeper.Instantiate(ctx, codeID, creator, nil, initMsgBz, "some label", sdk.NewCoins(sdk.NewInt64Coin("denom", 0)))
+	// make the label a random base64 string, because why not?
+	contractAddress, err := keeper.Instantiate(ctx, codeID, creator, nil, initMsgBz, base64.RawURLEncoding.EncodeToString(nonce), sdk.NewCoins(sdk.NewInt64Coin("denom", 0)))
 	if err != nil {
 		return nil, nil, extractInnerError(t, err, nonce, isErrorEncrypted)
 	}

--- a/x/compute/internal/types/keys.go
+++ b/x/compute/internal/types/keys.go
@@ -30,6 +30,7 @@ var (
 	ContractKeyPrefix       = []byte{0x02}
 	ContractStorePrefix     = []byte{0x03}
 	ContractEnclaveIdPrefix = []byte{0x04}
+	ContractLabelPrefix     = []byte{0x05}
 )
 
 // GetCodeKey constructs the key for retreiving the ID for the WASM code
@@ -51,4 +52,9 @@ func GetContractEnclaveKey(addr sdk.AccAddress) []byte {
 // GetContractStorePrefixKey returns the store prefix for the WASM contract instance
 func GetContractStorePrefixKey(addr sdk.AccAddress) []byte {
 	return append(ContractStorePrefix, addr...)
+}
+
+// GetContractStorePrefixKey returns the store prefix for the WASM contract instance
+func GetContractLabelPrefix(addr string) []byte {
+	return append(ContractLabelPrefix, []byte(addr)...)
 }


### PR DESCRIPTION
Instead of `contract execute secret1uhesauhsdfhuasfduh '{stuff}'` you can now use `contract execute '{}' --label RPRCCoin`

That means that labels are unique, and if you try creating with an existing label the instantiate will fail, so user beware. Also, the instantiate TX will cost more the longer your label is. 

Added a `secretcli q compute label <name>` to check if your label is free or taken