### PR TITLE
Testnet docs: Clarification of CLI, faucet, create validator

### DIFF
--- a/docs/testnet/run-full-node-testnet.md
+++ b/docs/testnet/run-full-node-testnet.md
@@ -1,6 +1,6 @@
 # How To Join Secret Network as a Full Node on Testnet
 
-This document details how to join the Secret Network `testnet` as a validator.
+This document details how to join the Secret Network `testnet` as a full node. Once your full node is running, you can turn it into a validator in the optional last step.
 
 ## Requirements
 
@@ -9,7 +9,6 @@ This document details how to join the Secret Network `testnet` as a validator.
 - Open ports `TCP 26656 & 26657` _Note: If you're behind a router or firewall then you'll need to port forward on the network device._
 - Reading https://docs.tendermint.com/master/tendermint-core/running-in-production.html
 - RPC address of an already active node. You can use `bootstrap.pub.testnet.enigma.co:26657`, or any other node that exposes RPC services.
-- Account with at least 1 SCRT
 
 ### Minimum requirements
 
@@ -105,7 +104,13 @@ PUBLIC_KEY=$(secretd parse attestation_cert.der 2> /dev/null | cut -c 3-)
 echo $PUBLIC_KEY
 ```
 
-### 11. Config `secretcli`
+### 11. Config `secretcli`, generate a key and get some test-SCRT from the faucet
+
+The steps using `secretcli` can be run on any machine, they don't need to be on the full node itself. We'll refer to the machine where you are using `secretcli` as the "CLI machine" below.
+
+To run the steps with `secretcli` on another machine, [set up the CLI](https://github.com/enigmampc/SecretNetwork/blob/master/docs/testnet/install_cli.md) there.
+
+Configure `secretcli`. Initially you'll be using the bootstrap node, as you'll need to connect to a running node and your own node is not running yet.
 
 ```bash
 secretcli config chain-id enigma-pub-testnet-1
@@ -115,15 +120,25 @@ secretcli config output json
 secretcli config indent true
 ```
 
-### 12. Register your node on-chain
-
-This step can be run from any location (doesn't have to be from the same node)
+Set up a key. Make sure you backup the mnemonic and the keyring password.
 
 ```bash
-secretcli tx register auth <path/to/attestation_cert.der> --from <your account>
+secretcli keys add mykey
+```
+
+This will output your address, a 45 character-string starting with `secret1...`. Copy/paste it to get some test-SCRT from [the faucet](https://faucet.pub.testnet.enigma.co/). Continue when you have confirmed your account has some test-SCRT in it.
+
+### 12. Register your node on-chain
+
+Run this step on the CLI machine. If you're using different CLI machine than the full node, copy `attestation_cert.der` from the full node to the CLI machine.
+
+```bash
+secretcli tx register auth <path/to/attestation_cert.der> --from <key-alias>
 ```
 
 ### 13. Pull & check your node's encrypted seed from the network
+
+Run this step on the CLI machine.
 
 ```bash
 SEED=$(secretcli query register seed "$PUBLIC_KEY" | cut -c 3-)
@@ -132,14 +147,20 @@ echo $SEED
 
 ### 14. Get additional network parameters
 
-These are necessary to configure the node before it starts
+Run this step on the CLI machine.
+
+These are necessary to configure the node before it starts.
 
 ```bash
 secretcli query register secret-network-params
 ls -lh ./io-master-cert.der ./node-master-cert.der
 ```
 
+If you're using different CLI machine than the validator node, copy `node-master-cert.der` from the CLI machine to the validator node.
+
 ### 15. Configure your secret node
+
+From here on, run commands on the full node again.
 
 ```bash
 mkdir -p ~/.secretd/.node
@@ -203,8 +224,9 @@ And publish yourself as a node with this ID:
 <your-node-id>@<your-public-ip>:26656
 ```
 
-So if someone wants to add you as a peer, have them add the above address to their `persistent_peers` in their `~/.secretd/config/config.toml`.  
-And if someone wants to use you from their `secretcli` then have them run:
+If someone wants to add you as a peer, have them add the above address to their `persistent_peers` in their `~/.secretd/config/config.toml`.  
+
+And if someone wants to use your node from their `secretcli` then have them run:
 
 ```bash
 secretcli config chain-id enigma-pub-testnet-1
@@ -212,3 +234,41 @@ secretcli config output json
 secretcli config indent true
 secretcli config node tcp://<your-public-ip>:26657
 ```
+
+### 22. Optional: make your full node a validator
+
+Your full node is now part of the network, storing and verifying chain data and secret contracts, and helping to distribute transactions and blocks. It's usable as a sentry node, for people to connect their CLI or light clients, or just to support the network.
+
+It is however not producing blocks yet, and you can't delegate funds to it for staking. To do that that you'll have to turn it into a validator by submitting a `create-validator` transaction.
+
+On the full node, get the pubkey of the node:
+
+```bash
+secretd tendermint show-validator
+```
+
+The pubkey is an 83-character string starting with `secretvalconspub...`.
+
+On the CLI machine, run the following command. The account you use becomes the operator account for your validator, which you'll use to collect rewards, participate in on-chain governance, etc, so make sure you keep good backups of the key. `<moniker>` is the name for your validator which is shown e.g. in block explorers.
+
+```bash
+secretcli tx staking create-validator \
+  --amount=<amount-to-delegate-to-yourself>uscrt \
+  --pubkey=<pubkey of the full node> \
+  --commission-rate="0.10" \
+  --commission-max-rate="0.20" \
+  --commission-max-change-rate="0.01" \
+  --min-self-delegation="1" \
+  --moniker="<moniker>" \
+  --from=<key-alias>
+```
+
+The `create-validator` command allows using some more parameters. For more info on these and the additional parameters, run `secretcli tx staking create-validator --help`.
+
+After you submitted the transaction, check you've been added as a validator:
+
+```bash
+secretcli q staking validators | grep moniker
+```
+
+Congratulations! You are now running a validator on the Secret Network testnet.

--- a/docs/testnet/run-full-node-testnet.md
+++ b/docs/testnet/run-full-node-testnet.md
@@ -77,6 +77,12 @@ cd ~/
 
 ### 8. Initialize secret enclave
 
+Make sure the directory `~/.sgx-secrets` exists:
+
+```bash
+mkdir ~/.sgx-secrets
+```
+
 Make sure SGX is enabled and running or this step might fail.
 
 ```bash
@@ -108,7 +114,7 @@ echo $PUBLIC_KEY
 
 The steps using `secretcli` can be run on any machine, they don't need to be on the full node itself. We'll refer to the machine where you are using `secretcli` as the "CLI machine" below.
 
-To run the steps with `secretcli` on another machine, [set up the CLI](https://github.com/enigmampc/SecretNetwork/blob/master/docs/testnet/install_cli.md) there.
+To run the steps with `secretcli` on another machine, [set up the CLI](install_cli.md) there.
 
 Configure `secretcli`. Initially you'll be using the bootstrap node, as you'll need to connect to a running node and your own node is not running yet.
 


### PR DESCRIPTION
- Explain how the CLI can be run on a different machine
- Add instructions for getting test-SCRT from the faucet
- Add last step to create a validator. In the mainnet docs there is a separate MD file for this, but I think having it as a step here makes it a nice concise complete instruction.