### PR TITLE
#423 reset command

### DIFF
--- a/cmd/secretd/attestation.go
+++ b/cmd/secretd/attestation.go
@@ -234,19 +234,26 @@ func ResetEnclave(_ *server.Context, _ *codec.Codec) *cobra.Command {
 
 			// remove .secretd/.node/seed.json
 			path := filepath.Join(app.DefaultNodeHome, reg.SecretNodeCfgFolder, reg.SecretNodeSeedConfig)
-			if _, err := os.Stat(path); os.IsExist(err) {
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				fmt.Printf("Removing %s\n", path)
 				err = os.Remove(path)
 				if err != nil {
 					return err
 				}
+			} else {
+				if err != nil {
+					println(err.Error())
+				}
 			}
+
 
 			// remove sgx_secrets
 			sgxSecretsDir := os.Getenv("SCRT_SGX_STORAGE")
 			if sgxSecretsDir == "" {
 				sgxSecretsDir = os.ExpandEnv("$HOME/.sgx_secrets")
 			}
-			if _, err := os.Stat(sgxSecretsDir); os.IsExist(err) {
+			if _, err := os.Stat(sgxSecretsDir); !os.IsNotExist(err) {
+				fmt.Printf("Removing %s\n", sgxSecretsDir)
 				err = os.RemoveAll(sgxSecretsDir)
 				if err != nil {
 					return err
@@ -254,6 +261,10 @@ func ResetEnclave(_ *server.Context, _ *codec.Codec) *cobra.Command {
 				err := os.MkdirAll(sgxSecretsDir, 644)
 				if err != nil {
 					return err
+				}
+			} else {
+				if err != nil {
+					println(err.Error())
 				}
 			}
 			return nil

--- a/cmd/secretd/main.go
+++ b/cmd/secretd/main.go
@@ -52,6 +52,7 @@ func main() {
 	rootCmd.AddCommand(InitAttestation(ctx, cdc))
 	rootCmd.AddCommand(ParseCert(ctx, cdc))
 	rootCmd.AddCommand(ConfigureSecret(ctx, cdc))
+	rootCmd.AddCommand(ResetEnclave(ctx, cdc))
 	rootCmd.AddCommand(InitBootstrapCmd(ctx, cdc, app.ModuleBasics))
 	rootCmd.AddCommand(genutilcli.InitCmd(ctx, cdc, app.ModuleBasics, app.DefaultNodeHome))
 	rootCmd.AddCommand(genutilcli.CollectGenTxsCmd(ctx, cdc, auth.GenesisAccountIterator{}, app.DefaultNodeHome))


### PR DESCRIPTION
#423 added a command to delete the contents of the .sgx_secrets folder and seed.json from `.secretd/.node/`