### PR TITLE
Enclave tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,15 +114,15 @@ build-linux: vendor
 	go build -mod=readonly -tags "$(GO_TAGS) secretcli" -ldflags '$(LD_FLAGS)' ./cmd/secretcli
 
 build_windows:
-	# CLI only 
+	# CLI only
 	GOOS=windows GOARCH=amd64 $(MAKE) cli
 
 build_macos:
-	# CLI only 
+	# CLI only
 	GOOS=darwin GOARCH=amd64 $(MAKE) cli
 
 build_arm_linux:
-	# CLI only 
+	# CLI only
 	GOOS=linux GOARCH=arm64 $(MAKE) cli
 
 build_all: build-linux build_windows build_macos build_arm_linux
@@ -180,8 +180,8 @@ clean:
 	-rm -rf /tmp/SecretNetwork
 	-rm -f ./secretcli*
 	-rm -f ./secretd*
-	-rm -f ./librust_cosmwasm_enclave.signed.so 
-	-rm -f ./x/compute/internal/keeper/librust_cosmwasm_enclave.signed.so 
+	-rm -f ./librust_cosmwasm_enclave.signed.so
+	-rm -f ./x/compute/internal/keeper/librust_cosmwasm_enclave.signed.so
 	-rm -f ./go-cosmwasm/api/libgo_cosmwasm.so
 	-rm -f ./enigma-blockchain*.deb
 	-rm -f ./SHA256SUMS*
@@ -257,6 +257,11 @@ go-tests: build-test-contract
 	cp ./cosmwasm/packages/wasmi-runtime/librust_cosmwasm_enclave.signed.so ./x/compute/internal/keeper
 	mkdir -p ./x/compute/internal/keeper/.sgx_secrets
 	SGX_MODE=SW go test -p 1 -v ./x/compute/internal/...
+
+.PHONY: enclave-tests
+enclave-tests:
+	$(MAKE) -C go-cosmwasm enclave-tests
+
 
 build-cosmwasm-test-contracts:
 	# echo "" | sudo add-apt-repository ppa:hnakamur/binaryen

--- a/cosmwasm/packages/sgx-vm/Cargo.toml
+++ b/cosmwasm/packages/sgx-vm/Cargo.toml
@@ -32,6 +32,7 @@ backtraces = ["snafu/backtraces"]
 # we keep this optional, to allow possible future integration (or different Cosmos Backends)
 iterator = ["cosmwasm-std/iterator"]
 staking = ["cosmwasm-std/staking"]
+enclave-tests = []
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published

--- a/cosmwasm/packages/sgx-vm/src/enclave_tests.rs
+++ b/cosmwasm/packages/sgx-vm/src/enclave_tests.rs
@@ -1,0 +1,10 @@
+// I reexport `sgx_types` here so that `go-cosmwasm` doesn't need to specify it as a dev-dependency.
+pub use sgx_types;
+use sgx_types::{sgx_enclave_id_t, sgx_status_t};
+
+pub use crate::enclave::get_enclave;
+
+#[link(name = "rust_cosmwasm_enclave.signed")]
+extern "C" {
+    pub fn ecall_run_tests(eid: sgx_enclave_id_t) -> sgx_status_t;
+}

--- a/cosmwasm/packages/sgx-vm/src/lib.rs
+++ b/cosmwasm/packages/sgx-vm/src/lib.rs
@@ -22,6 +22,9 @@ mod enclave;
 mod seed;
 mod wasmi;
 
+#[cfg(feature = "enclave-tests")]
+pub mod enclave_tests;
+
 pub use crate::cache::CosmCache;
 pub use crate::calls::{
     call_handle, call_handle_raw, call_init, call_init_raw, call_migrate, call_migrate_raw,

--- a/cosmwasm/packages/wasmi-runtime/Enclave.edl
+++ b/cosmwasm/packages/wasmi-runtime/Enclave.edl
@@ -15,7 +15,6 @@ enclave {
     include "target/headers/enclave-ffi-types.h"
 
     trusted {
-
         EnclaveBuffer ecall_allocate(
             [in, count=length] const uint8_t* buffer,
             uintptr_t length
@@ -78,6 +77,7 @@ enclave {
             uintptr_t msg_len
         );
 
+        public void ecall_run_tests();
     };
 
     untrusted {

--- a/cosmwasm/packages/wasmi-runtime/Makefile
+++ b/cosmwasm/packages/wasmi-runtime/Makefile
@@ -121,6 +121,9 @@ $(Enclave_EDL_Products): Enclave.edl
 check:
 	RUST_TARGET_PATH=$(Rust_Target_Path) RUSTFLAGS=$(Rust_Flags) xargo check --features "$(FEATURES)" --target x86_64-unknown-linux-sgx
 
+check-enclave-tests:
+	RUST_TARGET_PATH=$(Rust_Target_Path) RUSTFLAGS=$(Rust_Flags) xargo check --features "test,$(FEATURES)" --target x86_64-unknown-linux-sgx
+
 clippy:
 	RUST_TARGET_PATH=$(Rust_Target_Path) RUSTFLAGS=$(Rust_Flags) xargo clippy --features "$(FEATURES)" --target x86_64-unknown-linux-sgx -- -D warnings
 

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/aes_siv.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/aes_siv.rs
@@ -59,52 +59,52 @@ fn aes_siv_decrypt(
     })
 }
 
-#[cfg(feature = "test")]
-pub mod tests {
-
-    use super::{aes_siv_decrypt, aes_siv_encrypt};
-
-    // todo: fix test vectors to actually work
-    fn test_aes_encrypt() {
-        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let aad: Vec<&[u8]> = vec![
-            b"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
-            b"102030405060708090a0",
-            b"09f911029d74e35bd84156c5635688c0",
-        ];
-        let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
-        let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
-
-        let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
-
-        assert_eq!(result.as_slice(), &ciphertext)
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_aes_decrypt() {
-        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let aad: Vec<&[u8]> = vec![
-            b"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
-            b"102030405060708090a0",
-            b"09f911029d74e35bd84156c5635688c0",
-        ];
-        let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
-        let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
-
-        let result = aes_siv_decrypt(ciphertext, &aad, &key).unwrap();
-
-        assert_eq!(result.as_slice(), &plaintext)
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_aes_encrypt_empty_aad() {
-        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let aad: Vec<&[u8]> = vec![];
-        let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
-        let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
-
-        let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
-
-        assert_eq!(result.as_slice(), &ciphertext)
-    }
-}
+// #[cfg(feature = "test")]
+// pub mod tests {
+//
+//     use super::{aes_siv_decrypt, aes_siv_encrypt};
+//
+//     // todo: fix test vectors to actually work
+//     fn test_aes_encrypt() {
+//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+//         let aad: Vec<&[u8]> = vec![
+//             b"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+//             b"102030405060708090a0",
+//             b"09f911029d74e35bd84156c5635688c0",
+//         ];
+//         let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
+//         let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
+//
+//         let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
+//
+//         assert_eq!(result.as_slice(), &ciphertext)
+//     }
+//
+//     // todo: fix test vectors to actually work
+//     fn test_aes_decrypt() {
+//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+//         let aad: Vec<&[u8]> = vec![
+//             b"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+//             b"102030405060708090a0",
+//             b"09f911029d74e35bd84156c5635688c0",
+//         ];
+//         let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
+//         let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
+//
+//         let result = aes_siv_decrypt(ciphertext, &aad, &key).unwrap();
+//
+//         assert_eq!(result.as_slice(), &plaintext)
+//     }
+//
+//     // todo: fix test vectors to actually work
+//     fn test_aes_encrypt_empty_aad() {
+//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+//         let aad: Vec<&[u8]> = vec![];
+//         let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
+//         let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
+//
+//         let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
+//
+//         assert_eq!(result.as_slice(), &ciphertext)
+//     }
+// }

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/aes_siv.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/aes_siv.rs
@@ -59,52 +59,52 @@ fn aes_siv_decrypt(
     })
 }
 
-// #[cfg(feature = "test")]
-// pub mod tests {
-//
-//     use super::{aes_siv_decrypt, aes_siv_encrypt};
-//
-//     // todo: fix test vectors to actually work
-//     fn test_aes_encrypt() {
-//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-//         let aad: Vec<&[u8]> = vec![
-//             b"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
-//             b"102030405060708090a0",
-//             b"09f911029d74e35bd84156c5635688c0",
-//         ];
-//         let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
-//         let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
-//
-//         let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
-//
-//         assert_eq!(result.as_slice(), &ciphertext)
-//     }
-//
-//     // todo: fix test vectors to actually work
-//     fn test_aes_decrypt() {
-//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-//         let aad: Vec<&[u8]> = vec![
-//             b"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
-//             b"102030405060708090a0",
-//             b"09f911029d74e35bd84156c5635688c0",
-//         ];
-//         let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
-//         let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
-//
-//         let result = aes_siv_decrypt(ciphertext, &aad, &key).unwrap();
-//
-//         assert_eq!(result.as_slice(), &plaintext)
-//     }
-//
-//     // todo: fix test vectors to actually work
-//     fn test_aes_encrypt_empty_aad() {
-//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-//         let aad: Vec<&[u8]> = vec![];
-//         let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
-//         let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
-//
-//         let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
-//
-//         assert_eq!(result.as_slice(), &ciphertext)
-//     }
-// }
+#[cfg(feature = "test")]
+pub mod tests {
+
+    use super::{aes_siv_decrypt, aes_siv_encrypt};
+
+    // todo: fix test vectors to actually work
+    fn test_aes_encrypt() {
+        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let aad: Vec<&[u8]> = vec![
+            b"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+            b"102030405060708090a0",
+            b"09f911029d74e35bd84156c5635688c0",
+        ];
+        let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
+        let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
+
+        let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
+
+        assert_eq!(result.as_slice(), &ciphertext)
+    }
+
+    // todo: fix test vectors to actually work
+    fn test_aes_decrypt() {
+        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let aad: Vec<&[u8]> = vec![
+            b"00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+            b"102030405060708090a0",
+            b"09f911029d74e35bd84156c5635688c0",
+        ];
+        let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
+        let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
+
+        let result = aes_siv_decrypt(ciphertext, &aad, &key).unwrap();
+
+        assert_eq!(result.as_slice(), &plaintext)
+    }
+
+    // todo: fix test vectors to actually work
+    fn test_aes_encrypt_empty_aad() {
+        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let aad: Vec<&[u8]> = vec![];
+        let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
+        let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
+
+        let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
+
+        assert_eq!(result.as_slice(), &ciphertext)
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/aes_siv.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/aes_siv.rs
@@ -75,9 +75,9 @@ pub mod tests {
         let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
         let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
 
-        let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
+        let result = aes_siv_encrypt(plaintext, Some(&aad), &key).unwrap();
 
-        assert_eq!(result.as_slice(), &ciphertext)
+        assert_eq!(result.as_slice(), &ciphertext[..])
     }
 
     // todo: fix test vectors to actually work
@@ -91,9 +91,9 @@ pub mod tests {
         let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
         let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
 
-        let result = aes_siv_decrypt(ciphertext, &aad, &key).unwrap();
+        let result = aes_siv_decrypt(ciphertext, Some(&aad), &key).unwrap();
 
-        assert_eq!(result.as_slice(), &plaintext)
+        assert_eq!(result.as_slice(), &plaintext[..])
     }
 
     // todo: fix test vectors to actually work
@@ -103,8 +103,8 @@ pub mod tests {
         let plaintext = b"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553";
         let ciphertext = b"7bdb6e3b432667eb06f4d14bff2fbd0fcb900f2fddbe404326601965c889bf17dba77ceb094fa663b7a3f748ba8af829ea64ad544a272e9c485b62a3fd5c0d";
 
-        let result = aes_siv_encrypt(plaintext, &aad, &key).unwrap();
+        let result = aes_siv_encrypt(plaintext, Some(&aad), &key).unwrap();
 
-        assert_eq!(result.as_slice(), &ciphertext)
+        assert_eq!(result.as_slice(), &ciphertext[..])
     }
 }

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/kdf.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/kdf.rs
@@ -64,20 +64,18 @@ impl From<hkdf::Okm<'_, My<usize>>> for My<Vec<u8>> {
 
 #[cfg(feature = "test")]
 pub mod tests {
-    use super::{
-        Keychain, CONSENSUS_SEED_SEALING_PATH, KEY_MANAGER, REGISTRATION_KEY_SEALING_PATH,
-    };
     use crate::crypto::CryptoError;
     use crate::crypto::{Kdf, KeyPair, Seed};
 
-    // todo: fix test vectors to actually work
-    fn test_derive_key() {
-        let seed = Seed::new_from_slice(&[10u8; 32]);
-
-        let kdf1 = seed.derive_key_from_this(&1.to_be_bytes());
-        let kdf2 = seed.derive_key_from_this(&2.to_be_bytes());
-
-        assert_eq!(kdf1, b"SOME VALUE");
-        assert_eq!(kdf2, b"SOME VALUE");
-    }
+    // commented since this is all outdated
+    // // todo: fix test vectors to actually work
+    // pub fn test_derive_key() {
+    //     let seed = Seed::new_from_slice(&[10u8; 32]);
+    //
+    //     let kdf1 = seed.derive_key_from_this(&1.to_be_bytes());
+    //     let kdf2 = seed.derive_key_from_this(&2.to_be_bytes());
+    //
+    //     assert_eq!(kdf1, b"SOME VALUE");
+    //     assert_eq!(kdf2, b"SOME VALUE");
+    // }
 }

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/kdf.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/kdf.rs
@@ -62,22 +62,22 @@ impl From<hkdf::Okm<'_, My<usize>>> for My<Vec<u8>> {
     }
 }
 
-#[cfg(feature = "test")]
-pub mod tests {
-    use super::{
-        Keychain, CONSENSUS_SEED_SEALING_PATH, KEY_MANAGER, REGISTRATION_KEY_SEALING_PATH,
-    };
-    use crate::crypto::CryptoError;
-    use crate::crypto::{Kdf, KeyPair, Seed};
-
-    // todo: fix test vectors to actually work
-    fn test_derive_key() {
-        let seed = Seed::new_from_slice(&[10u8; 32]);
-
-        let kdf1 = seed.derive_key_from_this(&1.to_be_bytes());
-        let kdf2 = seed.derive_key_from_this(&2.to_be_bytes());
-
-        assert_eq!(kdf1, b"SOME VALUE");
-        assert_eq!(kdf2, b"SOME VALUE");
-    }
-}
+// #[cfg(feature = "test")]
+// pub mod tests {
+//     use super::{
+//         Keychain, CONSENSUS_SEED_SEALING_PATH, KEY_MANAGER, REGISTRATION_KEY_SEALING_PATH,
+//     };
+//     use crate::crypto::CryptoError;
+//     use crate::crypto::{Kdf, KeyPair, Seed};
+//
+//     // todo: fix test vectors to actually work
+//     fn test_derive_key() {
+//         let seed = Seed::new_from_slice(&[10u8; 32]);
+//
+//         let kdf1 = seed.derive_key_from_this(&1.to_be_bytes());
+//         let kdf2 = seed.derive_key_from_this(&2.to_be_bytes());
+//
+//         assert_eq!(kdf1, b"SOME VALUE");
+//         assert_eq!(kdf2, b"SOME VALUE");
+//     }
+// }

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/kdf.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/kdf.rs
@@ -62,22 +62,22 @@ impl From<hkdf::Okm<'_, My<usize>>> for My<Vec<u8>> {
     }
 }
 
-// #[cfg(feature = "test")]
-// pub mod tests {
-//     use super::{
-//         Keychain, CONSENSUS_SEED_SEALING_PATH, KEY_MANAGER, REGISTRATION_KEY_SEALING_PATH,
-//     };
-//     use crate::crypto::CryptoError;
-//     use crate::crypto::{Kdf, KeyPair, Seed};
-//
-//     // todo: fix test vectors to actually work
-//     fn test_derive_key() {
-//         let seed = Seed::new_from_slice(&[10u8; 32]);
-//
-//         let kdf1 = seed.derive_key_from_this(&1.to_be_bytes());
-//         let kdf2 = seed.derive_key_from_this(&2.to_be_bytes());
-//
-//         assert_eq!(kdf1, b"SOME VALUE");
-//         assert_eq!(kdf2, b"SOME VALUE");
-//     }
-// }
+#[cfg(feature = "test")]
+pub mod tests {
+    use super::{
+        Keychain, CONSENSUS_SEED_SEALING_PATH, KEY_MANAGER, REGISTRATION_KEY_SEALING_PATH,
+    };
+    use crate::crypto::CryptoError;
+    use crate::crypto::{Kdf, KeyPair, Seed};
+
+    // todo: fix test vectors to actually work
+    fn test_derive_key() {
+        let seed = Seed::new_from_slice(&[10u8; 32]);
+
+        let kdf1 = seed.derive_key_from_this(&1.to_be_bytes());
+        let kdf2 = seed.derive_key_from_this(&2.to_be_bytes());
+
+        assert_eq!(kdf1, b"SOME VALUE");
+        assert_eq!(kdf2, b"SOME VALUE");
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/key_manager.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/key_manager.rs
@@ -195,95 +195,95 @@ impl Keychain {
     }
 }
 
-// #[cfg(feature = "test")]
-// pub mod tests {
-//
-//     use super::{
-//         Keychain, CONSENSUS_SEED_SEALING_PATH, KEY_MANAGER, REGISTRATION_KEY_SEALING_PATH,
-//     };
-//     use crate::crypto::CryptoError;
-//     use crate::crypto::{KeyPair, Seed};
-//
-//     // todo: fix test vectors to actually work
-//     fn test_initial_keychain_state() {
-//         // clear previous data (if any)
-//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-//
-//         let keys = Keychain::new();
-//
-//         // todo: replace with actual checks
-//         assert_eq!(keys.get_registration_key(), Err(CryptoError));
-//         assert_eq!(keys.get_consensus_seed(), Err(CryptoError));
-//         assert_eq!(keys.get_consensus_io_exchange_keypair(), Err(CryptoError));
-//         assert_eq!(keys.get_consensus_state_ikm(), Err(CryptoError));
-//     }
-//
-//     // todo: fix test vectors to actually work
-//     fn test_initialize_keychain_seed() {
-//         // clear previous data (if any)
-//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-//
-//         let mut keys = Keychain::new();
-//
-//         let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-//
-//         keys.set_consensus_seed(seed);
-//         keys.generate_consensus_master_keys();
-//         // todo: replace with actual checks
-//         assert_eq!(keys.get_registration_key(), Err(CryptoError));
-//         assert_eq!(keys.get_consensus_seed().unwrap(), seed);
-//     }
-//
-//     // todo: fix test vectors to actually work
-//     fn test_initialize_keychain_registration() {
-//         // clear previous data (if any)
-//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-//
-//         let mut keys = Keychain::new();
-//
-//         let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
-//
-//         keys.set_registration_key(kp);
-//         // todo: replace with actual checks
-//         assert_eq!(keys.get_registration_key().unwrap(), kp);
-//     }
-//
-//     // todo: fix test vectors to actually work
-//     fn test_initialize_keys() {
-//         // clear previous data (if any)
-//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-//
-//         let mut keys = Keychain::new();
-//
-//         let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-//
-//         keys.set_consensus_seed(seed);
-//         keys.generate_consensus_master_keys();
-//         // todo: replace with actual checks
-//         assert_eq!(keys.get_consensus_io_exchange_keypair().unwrap(), seed);
-//         assert_eq!(keys.get_consensus_state_ikm().unwrap(), seed);
-//     }
-//
-//     // todo: fix test vectors to actually work
-//     fn test_key_manager() {
-//         // clear previous data (if any)
-//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-//
-//         let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-//         let mut keys = Keychain::new();
-//         keys.set_consensus_seed(seed);
-//         keys.generate_consensus_master_keys();
-//
-//         // todo: replace with actual checks
-//         assert_eq!(
-//             KEY_MANAGER.get_consensus_io_exchange_keypair().unwrap(),
-//             seed
-//         );
-//         assert_eq!(KEY_MANAGER.get_consensus_state_ikm().unwrap(), seed);
-//     }
-// }
+#[cfg(feature = "test")]
+pub mod tests {
+
+    use super::{
+        Keychain, CONSENSUS_SEED_SEALING_PATH, KEY_MANAGER, REGISTRATION_KEY_SEALING_PATH,
+    };
+    use crate::crypto::CryptoError;
+    use crate::crypto::{KeyPair, Seed};
+
+    // todo: fix test vectors to actually work
+    fn test_initial_keychain_state() {
+        // clear previous data (if any)
+        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+
+        let keys = Keychain::new();
+
+        // todo: replace with actual checks
+        assert_eq!(keys.get_registration_key(), Err(CryptoError));
+        assert_eq!(keys.get_consensus_seed(), Err(CryptoError));
+        assert_eq!(keys.get_consensus_io_exchange_keypair(), Err(CryptoError));
+        assert_eq!(keys.get_consensus_state_ikm(), Err(CryptoError));
+    }
+
+    // todo: fix test vectors to actually work
+    fn test_initialize_keychain_seed() {
+        // clear previous data (if any)
+        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+
+        let mut keys = Keychain::new();
+
+        let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
+        keys.set_consensus_seed(seed);
+        keys.generate_consensus_master_keys();
+        // todo: replace with actual checks
+        assert_eq!(keys.get_registration_key(), Err(CryptoError));
+        assert_eq!(keys.get_consensus_seed().unwrap(), seed);
+    }
+
+    // todo: fix test vectors to actually work
+    fn test_initialize_keychain_registration() {
+        // clear previous data (if any)
+        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+
+        let mut keys = Keychain::new();
+
+        let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
+
+        keys.set_registration_key(kp);
+        // todo: replace with actual checks
+        assert_eq!(keys.get_registration_key().unwrap(), kp);
+    }
+
+    // todo: fix test vectors to actually work
+    fn test_initialize_keys() {
+        // clear previous data (if any)
+        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+
+        let mut keys = Keychain::new();
+
+        let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
+        keys.set_consensus_seed(seed);
+        keys.generate_consensus_master_keys();
+        // todo: replace with actual checks
+        assert_eq!(keys.get_consensus_io_exchange_keypair().unwrap(), seed);
+        assert_eq!(keys.get_consensus_state_ikm().unwrap(), seed);
+    }
+
+    // todo: fix test vectors to actually work
+    fn test_key_manager() {
+        // clear previous data (if any)
+        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+
+        let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        let mut keys = Keychain::new();
+        keys.set_consensus_seed(seed);
+        keys.generate_consensus_master_keys();
+
+        // todo: replace with actual checks
+        assert_eq!(
+            KEY_MANAGER.get_consensus_io_exchange_keypair().unwrap(),
+            seed
+        );
+        assert_eq!(KEY_MANAGER.get_consensus_state_ikm().unwrap(), seed);
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/key_manager.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/key_manager.rs
@@ -195,95 +195,95 @@ impl Keychain {
     }
 }
 
-#[cfg(feature = "test")]
-pub mod tests {
-
-    use super::{
-        Keychain, CONSENSUS_SEED_SEALING_PATH, KEY_MANAGER, REGISTRATION_KEY_SEALING_PATH,
-    };
-    use crate::crypto::CryptoError;
-    use crate::crypto::{KeyPair, Seed};
-
-    // todo: fix test vectors to actually work
-    fn test_initial_keychain_state() {
-        // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-
-        let keys = Keychain::new();
-
-        // todo: replace with actual checks
-        assert_eq!(keys.get_registration_key(), Err(CryptoError));
-        assert_eq!(keys.get_consensus_seed(), Err(CryptoError));
-        assert_eq!(keys.get_consensus_io_exchange_keypair(), Err(CryptoError));
-        assert_eq!(keys.get_consensus_state_ikm(), Err(CryptoError));
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_initialize_keychain_seed() {
-        // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-
-        let mut keys = Keychain::new();
-
-        let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
-        keys.set_consensus_seed(seed);
-        keys.generate_consensus_master_keys();
-        // todo: replace with actual checks
-        assert_eq!(keys.get_registration_key(), Err(CryptoError));
-        assert_eq!(keys.get_consensus_seed().unwrap(), seed);
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_initialize_keychain_registration() {
-        // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-
-        let mut keys = Keychain::new();
-
-        let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
-
-        keys.set_registration_key(kp);
-        // todo: replace with actual checks
-        assert_eq!(keys.get_registration_key().unwrap(), kp);
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_initialize_keys() {
-        // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-
-        let mut keys = Keychain::new();
-
-        let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
-        keys.set_consensus_seed(seed);
-        keys.generate_consensus_master_keys();
-        // todo: replace with actual checks
-        assert_eq!(keys.get_consensus_io_exchange_keypair().unwrap(), seed);
-        assert_eq!(keys.get_consensus_state_ikm().unwrap(), seed);
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_key_manager() {
-        // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-
-        let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-        let mut keys = Keychain::new();
-        keys.set_consensus_seed(seed);
-        keys.generate_consensus_master_keys();
-
-        // todo: replace with actual checks
-        assert_eq!(
-            KEY_MANAGER.get_consensus_io_exchange_keypair().unwrap(),
-            seed
-        );
-        assert_eq!(KEY_MANAGER.get_consensus_state_ikm().unwrap(), seed);
-    }
-}
+// #[cfg(feature = "test")]
+// pub mod tests {
+//
+//     use super::{
+//         Keychain, CONSENSUS_SEED_SEALING_PATH, KEY_MANAGER, REGISTRATION_KEY_SEALING_PATH,
+//     };
+//     use crate::crypto::CryptoError;
+//     use crate::crypto::{KeyPair, Seed};
+//
+//     // todo: fix test vectors to actually work
+//     fn test_initial_keychain_state() {
+//         // clear previous data (if any)
+//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+//
+//         let keys = Keychain::new();
+//
+//         // todo: replace with actual checks
+//         assert_eq!(keys.get_registration_key(), Err(CryptoError));
+//         assert_eq!(keys.get_consensus_seed(), Err(CryptoError));
+//         assert_eq!(keys.get_consensus_io_exchange_keypair(), Err(CryptoError));
+//         assert_eq!(keys.get_consensus_state_ikm(), Err(CryptoError));
+//     }
+//
+//     // todo: fix test vectors to actually work
+//     fn test_initialize_keychain_seed() {
+//         // clear previous data (if any)
+//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+//
+//         let mut keys = Keychain::new();
+//
+//         let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+//
+//         keys.set_consensus_seed(seed);
+//         keys.generate_consensus_master_keys();
+//         // todo: replace with actual checks
+//         assert_eq!(keys.get_registration_key(), Err(CryptoError));
+//         assert_eq!(keys.get_consensus_seed().unwrap(), seed);
+//     }
+//
+//     // todo: fix test vectors to actually work
+//     fn test_initialize_keychain_registration() {
+//         // clear previous data (if any)
+//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+//
+//         let mut keys = Keychain::new();
+//
+//         let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
+//
+//         keys.set_registration_key(kp);
+//         // todo: replace with actual checks
+//         assert_eq!(keys.get_registration_key().unwrap(), kp);
+//     }
+//
+//     // todo: fix test vectors to actually work
+//     fn test_initialize_keys() {
+//         // clear previous data (if any)
+//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+//
+//         let mut keys = Keychain::new();
+//
+//         let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+//
+//         keys.set_consensus_seed(seed);
+//         keys.generate_consensus_master_keys();
+//         // todo: replace with actual checks
+//         assert_eq!(keys.get_consensus_io_exchange_keypair().unwrap(), seed);
+//         assert_eq!(keys.get_consensus_state_ikm().unwrap(), seed);
+//     }
+//
+//     // todo: fix test vectors to actually work
+//     fn test_key_manager() {
+//         // clear previous data (if any)
+//         std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
+//         std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+//
+//         let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+//         let mut keys = Keychain::new();
+//         keys.set_consensus_seed(seed);
+//         keys.generate_consensus_master_keys();
+//
+//         // todo: replace with actual checks
+//         assert_eq!(
+//             KEY_MANAGER.get_consensus_io_exchange_keypair().unwrap(),
+//             seed
+//         );
+//         assert_eq!(KEY_MANAGER.get_consensus_state_ikm().unwrap(), seed);
+//     }
+// }

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/key_manager.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/key_manager.rs
@@ -207,83 +207,84 @@ pub mod tests {
     // todo: fix test vectors to actually work
     fn test_initial_keychain_state() {
         // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+        std::sgxfs::remove(&*CONSENSUS_SEED_SEALING_PATH);
+        std::sgxfs::remove(&*REGISTRATION_KEY_SEALING_PATH);
 
         let keys = Keychain::new();
 
         // todo: replace with actual checks
-        assert_eq!(keys.get_registration_key(), Err(CryptoError));
-        assert_eq!(keys.get_consensus_seed(), Err(CryptoError));
-        assert_eq!(keys.get_consensus_io_exchange_keypair(), Err(CryptoError));
-        assert_eq!(keys.get_consensus_state_ikm(), Err(CryptoError));
+        // assert_eq!(keys.get_registration_key(), Err(CryptoError));
+        // assert_eq!(keys.get_consensus_seed(), Err(CryptoError));
+        // assert_eq!(keys.get_consensus_io_exchange_keypair(), Err(CryptoError));
+        // assert_eq!(keys.get_consensus_state_ikm(), Err(CryptoError));
     }
 
-    // todo: fix test vectors to actually work
-    fn test_initialize_keychain_seed() {
-        // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
+    // commented out since it uses outdated methods
+    // // todo: fix test vectors to actually work
+    // fn test_initialize_keychain_seed() {
+    //     // clear previous data (if any)
+    //     std::sgxfs::remove(&*CONSENSUS_SEED_SEALING_PATH);
+    //     std::sgxfs::remove(&*REGISTRATION_KEY_SEALING_PATH);
+    //
+    //     let mut keys = Keychain::new();
+    //
+    //     let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    //
+    //     keys.set_consensus_seed(seed);
+    //     keys.generate_consensus_master_keys();
+    //     // todo: replace with actual checks
+    //     // assert_eq!(keys.get_registration_key(), Err(CryptoError));
+    //     assert_eq!(keys.get_consensus_seed().unwrap(), seed);
+    // }
 
-        let mut keys = Keychain::new();
-
-        let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
-        keys.set_consensus_seed(seed);
-        keys.generate_consensus_master_keys();
-        // todo: replace with actual checks
-        assert_eq!(keys.get_registration_key(), Err(CryptoError));
-        assert_eq!(keys.get_consensus_seed().unwrap(), seed);
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_initialize_keychain_registration() {
-        // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-
-        let mut keys = Keychain::new();
-
-        let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
-
-        keys.set_registration_key(kp);
-        // todo: replace with actual checks
-        assert_eq!(keys.get_registration_key().unwrap(), kp);
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_initialize_keys() {
-        // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-
-        let mut keys = Keychain::new();
-
-        let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
-        keys.set_consensus_seed(seed);
-        keys.generate_consensus_master_keys();
-        // todo: replace with actual checks
-        assert_eq!(keys.get_consensus_io_exchange_keypair().unwrap(), seed);
-        assert_eq!(keys.get_consensus_state_ikm().unwrap(), seed);
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_key_manager() {
-        // clear previous data (if any)
-        std::sgxfs::remove(&CONSENSUS_SEED_SEALING_PATH);
-        std::sgxfs::remove(&REGISTRATION_KEY_SEALING_PATH);
-
-        let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-        let mut keys = Keychain::new();
-        keys.set_consensus_seed(seed);
-        keys.generate_consensus_master_keys();
-
-        // todo: replace with actual checks
-        assert_eq!(
-            KEY_MANAGER.get_consensus_io_exchange_keypair().unwrap(),
-            seed
-        );
-        assert_eq!(KEY_MANAGER.get_consensus_state_ikm().unwrap(), seed);
-    }
+    // // todo: fix test vectors to actually work
+    // fn test_initialize_keychain_registration() {
+    //     // clear previous data (if any)
+    //     std::sgxfs::remove(&*CONSENSUS_SEED_SEALING_PATH);
+    //     std::sgxfs::remove(&*REGISTRATION_KEY_SEALING_PATH);
+    //
+    //     let mut keys = Keychain::new();
+    //
+    //     let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
+    //
+    //     keys.set_registration_key(kp);
+    //     // todo: replace with actual checks
+    //     assert_eq!(keys.get_registration_key().unwrap(), kp);
+    // }
+    //
+    // // todo: fix test vectors to actually work
+    // fn test_initialize_keys() {
+    //     // clear previous data (if any)
+    //     std::sgxfs::remove(&*CONSENSUS_SEED_SEALING_PATH);
+    //     std::sgxfs::remove(&*REGISTRATION_KEY_SEALING_PATH);
+    //
+    //     let mut keys = Keychain::new();
+    //
+    //     let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    //
+    //     keys.set_consensus_seed(seed);
+    //     keys.generate_consensus_master_keys();
+    //     // todo: replace with actual checks
+    //     assert_eq!(keys.get_consensus_io_exchange_keypair().unwrap(), seed);
+    //     assert_eq!(keys.get_consensus_state_ikm().unwrap(), seed);
+    // }
+    //
+    // // todo: fix test vectors to actually work
+    // fn test_key_manager() {
+    //     // clear previous data (if any)
+    //     std::sgxfs::remove(&*CONSENSUS_SEED_SEALING_PATH);
+    //     std::sgxfs::remove(&*REGISTRATION_KEY_SEALING_PATH);
+    //
+    //     let seed = Seed::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    //     let mut keys = Keychain::new();
+    //     keys.set_consensus_seed(seed);
+    //     keys.generate_consensus_master_keys();
+    //
+    //     // todo: replace with actual checks
+    //     assert_eq!(
+    //         KEY_MANAGER.get_consensus_io_exchange_keypair().unwrap(),
+    //         seed
+    //     );
+    //     assert_eq!(KEY_MANAGER.get_consensus_state_ikm().unwrap(), seed);
+    // }
 }

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/mod.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/mod.rs
@@ -1,5 +1,5 @@
 mod errors;
-mod kdf;
+pub(crate) mod kdf;
 pub mod key_manager;
 mod keys;
 mod storage;
@@ -23,3 +23,13 @@ pub use ed25519::{Ed25519PublicKey, KeyPair, PUBLIC_KEY_SIZE, SECRET_KEY_SIZE};
 
 pub use sha::{sha_256, HASH_SIZE};
 pub use traits::{Encryptable, Hmac, Kdf, SIVEncryptable, SealedKey, HMAC_SIGNATURE_SIZE};
+
+#[cfg(feature = "test")]
+pub mod tests {
+    use super::*;
+    pub fn run_tests() {
+        // kdf::tests::test_derive_key();
+        // storage::tests::test_open();
+        storage::tests::test_seal();
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/storage.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/storage.rs
@@ -69,9 +69,10 @@ fn open(filepath: &str) -> Result<Ed25519PrivateKey, EnclaveError> {
 pub mod tests {
 
     use super::{open, seal};
+    use log::*;
 
     // todo: fix test vectors to actually work
-    fn test_seal() {
+    pub fn test_seal() {
         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
         if let Err(e) = seal(key, "file") {
@@ -79,23 +80,17 @@ pub mod tests {
         };
     }
 
-    // todo: fix test vectors to actually work
-    fn test_open() {
-        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-
-        if let Err(e) = seal(key, "file") {
-            error!("Failed to seal data: {:?}", e)
-            // todo: fail
-        };
-
-        data = match open("file") {
-            Err(e) => {
-                error!("Failed to open data: {:?}", e)
-                // todo: fail
-            }
-            Ok(res) => res,
-        };
-
-        assert_eq!(data, key);
-    }
+    // // todo: fix test vectors to actually work
+    // pub fn test_open() {
+    //     let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    //
+    //     if let Err(e) = seal(key, "file") {
+    //         error!("Failed to seal data: {:?}", e)
+    //         // todo: fail
+    //     };
+    //
+    //     let data = open("file").expect(&format!("Failed to open data: {:?}", e));
+    //
+    //     assert_eq!(data, key);
+    // }
 }

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/storage.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/storage.rs
@@ -65,37 +65,37 @@ fn open(filepath: &str) -> Result<Ed25519PrivateKey, EnclaveError> {
     Ok(buf)
 }
 
-// #[cfg(feature = "test")]
-// pub mod tests {
-//
-//     use super::{open, seal};
-//
-//     // todo: fix test vectors to actually work
-//     fn test_seal() {
-//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-//
-//         if let Err(e) = seal(key, "file") {
-//             error!("Failed to seal data: {:?}", e)
-//         };
-//     }
-//
-//     // todo: fix test vectors to actually work
-//     fn test_open() {
-//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-//
-//         if let Err(e) = seal(key, "file") {
-//             error!("Failed to seal data: {:?}", e)
-//             // todo: fail
-//         };
-//
-//         data = match open("file") {
-//             Err(e) => {
-//                 error!("Failed to open data: {:?}", e)
-//                 // todo: fail
-//             }
-//             Ok(res) => res,
-//         };
-//
-//         assert_eq!(data, key);
-//     }
-// }
+#[cfg(feature = "test")]
+pub mod tests {
+
+    use super::{open, seal};
+
+    // todo: fix test vectors to actually work
+    fn test_seal() {
+        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        if let Err(e) = seal(key, "file") {
+            error!("Failed to seal data: {:?}", e)
+        };
+    }
+
+    // todo: fix test vectors to actually work
+    fn test_open() {
+        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        if let Err(e) = seal(key, "file") {
+            error!("Failed to seal data: {:?}", e)
+            // todo: fail
+        };
+
+        data = match open("file") {
+            Err(e) => {
+                error!("Failed to open data: {:?}", e)
+                // todo: fail
+            }
+            Ok(res) => res,
+        };
+
+        assert_eq!(data, key);
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/crypto/storage.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/crypto/storage.rs
@@ -65,37 +65,37 @@ fn open(filepath: &str) -> Result<Ed25519PrivateKey, EnclaveError> {
     Ok(buf)
 }
 
-#[cfg(feature = "test")]
-pub mod tests {
-
-    use super::{open, seal};
-
-    // todo: fix test vectors to actually work
-    fn test_seal() {
-        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-
-        if let Err(e) = seal(key, "file") {
-            error!("Failed to seal data: {:?}", e)
-        };
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_open() {
-        let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-
-        if let Err(e) = seal(key, "file") {
-            error!("Failed to seal data: {:?}", e)
-            // todo: fail
-        };
-
-        data = match open("file") {
-            Err(e) => {
-                error!("Failed to open data: {:?}", e)
-                // todo: fail
-            }
-            Ok(res) => res,
-        };
-
-        assert_eq!(data, key);
-    }
-}
+// #[cfg(feature = "test")]
+// pub mod tests {
+//
+//     use super::{open, seal};
+//
+//     // todo: fix test vectors to actually work
+//     fn test_seal() {
+//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+//
+//         if let Err(e) = seal(key, "file") {
+//             error!("Failed to seal data: {:?}", e)
+//         };
+//     }
+//
+//     // todo: fix test vectors to actually work
+//     fn test_open() {
+//         let key = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+//
+//         if let Err(e) = seal(key, "file") {
+//             error!("Failed to seal data: {:?}", e)
+//             // todo: fail
+//         };
+//
+//         data = match open("file") {
+//             Err(e) => {
+//                 error!("Failed to open data: {:?}", e)
+//                 // todo: fail
+//             }
+//             Ok(res) => res,
+//         };
+//
+//         assert_eq!(data, key);
+//     }
+// }

--- a/cosmwasm/packages/wasmi-runtime/src/lib.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/lib.rs
@@ -34,6 +34,8 @@ mod results;
 mod storage;
 mod utils;
 
+mod tests;
+
 static LOGGER: SimpleLogger = SimpleLogger;
 
 #[cfg(all(not(feature = "production"), feature = "SGX_MODE_HW"))]
@@ -58,10 +60,4 @@ fn init_logger() {
     log::set_logger(&LOGGER)
         .map(|()| log::set_max_level(LevelFilter::Trace))
         .unwrap();
-}
-
-// todo: figure out how we want to turn this on
-#[cfg(feature = "test")]
-fn run_test() {
-    println!("placeholder")
 }

--- a/cosmwasm/packages/wasmi-runtime/src/registration/attestation.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/attestation.rs
@@ -637,24 +637,25 @@ fn as_u32_le(array: [u8; 4]) -> u32 {
         + ((array[3] as u32) << 24)
 }
 
-#[cfg(feature = "test")]
-pub mod tests {
-    use crate::crypto::KeyPair;
-    use crate::registration::cert::verify_ra_cert;
-
-    use super::sgx_quote_sign_type_t;
-    use super::{create_attestation_certificate, get_ias_api_key, load_spid};
-
-    // todo: replace public key with real value
-    fn test_create_attestation_certificate() {
-        let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
-
-        let cert =
-            create_attestation_certificate(&kp, sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE)
-                .unwrap();
-
-        let result = verify_ra_cert(cert[1]).unwrap();
-
-        assert_eq!(result, kp.get_pubkey())
-    }
-}
+// commented out because it only contains one test
+// #[cfg(feature = "test")]
+// pub mod tests {
+//     use crate::crypto::KeyPair;
+//     use crate::registration::cert::verify_ra_cert;
+//
+//     use super::create_attestation_certificate;
+//     use super::sgx_quote_sign_type_t;
+//
+//     // todo: replace public key with real value
+//     pub fn test_create_attestation_certificate() {
+//         let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
+//
+//         let cert =
+//             create_attestation_certificate(&kp, sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE)
+//                 .unwrap();
+//
+//         let result = verify_ra_cert(cert[1]).unwrap();
+//
+//         assert_eq!(result, kp.get_pubkey())
+//     }
+// }

--- a/cosmwasm/packages/wasmi-runtime/src/registration/attestation.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/attestation.rs
@@ -637,24 +637,24 @@ fn as_u32_le(array: [u8; 4]) -> u32 {
         + ((array[3] as u32) << 24)
 }
 
-// #[cfg(feature = "test")]
-// pub mod tests {
-//     use crate::crypto::KeyPair;
-//     use crate::registration::cert::verify_ra_cert;
-//
-//     use super::sgx_quote_sign_type_t;
-//     use super::{create_attestation_certificate, get_ias_api_key, load_spid};
-//
-//     // todo: replace public key with real value
-//     fn test_create_attestation_certificate() {
-//         let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
-//
-//         let cert =
-//             create_attestation_certificate(&kp, sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE)
-//                 .unwrap();
-//
-//         let result = verify_ra_cert(cert[1]).unwrap();
-//
-//         assert_eq!(result, kp.get_pubkey())
-//     }
-// }
+#[cfg(feature = "test")]
+pub mod tests {
+    use crate::crypto::KeyPair;
+    use crate::registration::cert::verify_ra_cert;
+
+    use super::sgx_quote_sign_type_t;
+    use super::{create_attestation_certificate, get_ias_api_key, load_spid};
+
+    // todo: replace public key with real value
+    fn test_create_attestation_certificate() {
+        let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
+
+        let cert =
+            create_attestation_certificate(&kp, sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE)
+                .unwrap();
+
+        let result = verify_ra_cert(cert[1]).unwrap();
+
+        assert_eq!(result, kp.get_pubkey())
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/registration/attestation.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/attestation.rs
@@ -637,24 +637,24 @@ fn as_u32_le(array: [u8; 4]) -> u32 {
         + ((array[3] as u32) << 24)
 }
 
-#[cfg(feature = "test")]
-pub mod tests {
-    use crate::crypto::KeyPair;
-    use crate::registration::cert::verify_ra_cert;
-
-    use super::sgx_quote_sign_type_t;
-    use super::{create_attestation_certificate, get_ias_api_key, load_spid};
-
-    // todo: replace public key with real value
-    fn test_create_attestation_certificate() {
-        let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
-
-        let cert =
-            create_attestation_certificate(&kp, sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE)
-                .unwrap();
-
-        let result = verify_ra_cert(cert[1]).unwrap();
-
-        assert_eq!(result, kp.get_pubkey())
-    }
-}
+// #[cfg(feature = "test")]
+// pub mod tests {
+//     use crate::crypto::KeyPair;
+//     use crate::registration::cert::verify_ra_cert;
+//
+//     use super::sgx_quote_sign_type_t;
+//     use super::{create_attestation_certificate, get_ias_api_key, load_spid};
+//
+//     // todo: replace public key with real value
+//     fn test_create_attestation_certificate() {
+//         let kp = KeyPair::new_from_slice(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
+//
+//         let cert =
+//             create_attestation_certificate(&kp, sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE)
+//                 .unwrap();
+//
+//         let result = verify_ra_cert(cert[1]).unwrap();
+//
+//         assert_eq!(result, kp.get_pubkey())
+//     }
+// }

--- a/cosmwasm/packages/wasmi-runtime/src/registration/cert.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/cert.rs
@@ -378,28 +378,28 @@ fn verify_quote_status(quote_status: SgxQuoteStatus) -> Result<(), sgx_status_t>
     }
 }
 
-// #[cfg(feature = "test")]
-// pub mod tests {
-//     use crate::crypto::KeyPair;
-//
-//     use super::sgx_quote_sign_type_t;
-//     use super::verify_ra_cert;
-//
-//     fn test_validate_certificate_valid_sw_mode() {
-//         pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert");
-//         let result = verify_ra_cert(cert);
-//     }
-//
-//     fn test_validate_certificate_valid_signed() {
-//         pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert.der");
-//         let result = verify_ra_cert(cert);
-//     }
-//
-//     fn test_validate_certificate_invalid() {
-//         pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert_invalid");
-//         let result = verify_ra_cert(cert);
-//     }
-//
-//     // we want a weird test because this should never crash
-//     fn test_random_bytes_as_certificate() {}
-// }
+#[cfg(feature = "test")]
+pub mod tests {
+    use crate::crypto::KeyPair;
+
+    use super::sgx_quote_sign_type_t;
+    use super::verify_ra_cert;
+
+    fn test_validate_certificate_valid_sw_mode() {
+        pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert");
+        let result = verify_ra_cert(cert);
+    }
+
+    fn test_validate_certificate_valid_signed() {
+        pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert.der");
+        let result = verify_ra_cert(cert);
+    }
+
+    fn test_validate_certificate_invalid() {
+        pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert_invalid");
+        let result = verify_ra_cert(cert);
+    }
+
+    // we want a weird test because this should never crash
+    fn test_random_bytes_as_certificate() {}
+}

--- a/cosmwasm/packages/wasmi-runtime/src/registration/cert.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/cert.rs
@@ -378,28 +378,28 @@ fn verify_quote_status(quote_status: SgxQuoteStatus) -> Result<(), sgx_status_t>
     }
 }
 
-#[cfg(feature = "test")]
-pub mod tests {
-    use crate::crypto::KeyPair;
-
-    use super::sgx_quote_sign_type_t;
-    use super::verify_ra_cert;
-
-    fn test_validate_certificate_valid_sw_mode() {
-        pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert");
-        let result = verify_ra_cert(cert);
-    }
-
-    fn test_validate_certificate_valid_signed() {
-        pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert.der");
-        let result = verify_ra_cert(cert);
-    }
-
-    fn test_validate_certificate_invalid() {
-        pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert_invalid");
-        let result = verify_ra_cert(cert);
-    }
-
-    // we want a weird test because this should never crash
-    fn test_random_bytes_as_certificate() {}
-}
+// #[cfg(feature = "test")]
+// pub mod tests {
+//     use crate::crypto::KeyPair;
+//
+//     use super::sgx_quote_sign_type_t;
+//     use super::verify_ra_cert;
+//
+//     fn test_validate_certificate_valid_sw_mode() {
+//         pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert");
+//         let result = verify_ra_cert(cert);
+//     }
+//
+//     fn test_validate_certificate_valid_signed() {
+//         pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert.der");
+//         let result = verify_ra_cert(cert);
+//     }
+//
+//     fn test_validate_certificate_invalid() {
+//         pub const cert: &[u8] = include_bytes!("../testdata/attestation_cert_invalid");
+//         let result = verify_ra_cert(cert);
+//     }
+//
+//     // we want a weird test because this should never crash
+//     fn test_random_bytes_as_certificate() {}
+// }

--- a/cosmwasm/packages/wasmi-runtime/src/registration/mod.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/mod.rs
@@ -10,3 +10,11 @@ mod onchain;
 mod report;
 
 mod seed_exchange;
+
+#[cfg(feature = "test")]
+pub mod tests {
+    use super::*;
+    pub fn run_tests() {
+        // attestation::tests::test_create_attestation_certificate();
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/registration/report.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/report.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 
 use super::cert::{get_ias_auth_config, get_netscape_comment};
 
+#[derive(Debug)]
 pub enum Error {
     ReportParseError,
     ReportValidationError,

--- a/cosmwasm/packages/wasmi-runtime/src/registration/report.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/report.rs
@@ -651,150 +651,150 @@ impl AttestationReport {
     }
 }
 
-// #[cfg(feature = "test")]
-// pub mod tests {
-//     use serde_json::json;
-//     use std::io::Read;
-//     use std::untrusted::fs::File;
-//
-//     use super::*;
-//
-//     fn tls_ra_cert_der_v3() -> Vec<u8> {
-//         let mut cert = vec![];
-//         let mut f = File::open("fixtures/tls_ra_cert_v3.der").unwrap();
-//         f.read_to_end(&mut cert).unwrap();
-//
-//         cert
-//     }
-//
-//     fn tls_ra_cert_der_v4() -> Vec<u8> {
-//         let mut cert = vec![];
-//         let mut f = File::open("fixtures/tls_ra_cert_v4.der").unwrap();
-//         f.read_to_end(&mut cert).unwrap();
-//
-//         cert
-//     }
-//
-//     fn ias_root_ca_cert_der() -> Vec<u8> {
-//         let mut cert = vec![];
-//         let mut f = File::open("fixtures/ias_root_ca_cert.der").unwrap();
-//         f.read_to_end(&mut cert).unwrap();
-//
-//         cert
-//     }
-//
-//     fn attesation_report() -> Value {
-//         let report = json!({
-//             "version": 3,
-//             "timestamp": "2020-02-11T22:25:59.682915",
-//             "platformInfoBlob": "1502006504000900000D0D02040180030000000000000000000\
-//                                  A00000B000000020000000000000B2FE0AE0F7FD4D552BF7EF4\
-//                                  C938D44E349F1BD0E76F041362DC52B43B7B25994978D792137\
-//                                  90362F6DAE91797ACF5BD5072E45F9A60795D1FFB10140421D8\
-//                                  691FFD",
-//             "isvEnclaveQuoteStatus": "GROUP_OUT_OF_DATE",
-//             "isvEnclaveQuoteBody": "AgABAC8LAAAKAAkAAAAAAK1zRQOIpndiP4IhlnW2AkwAAAAA\
-//                                     AAAAAAAAAAAAAAAABQ4CBf+AAAAAAAAAAAAAAAAAAAAAAAAA\
-//                                     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAA\
-//                                     AAAAADMKqRCjd2eA4gAmrj2sB68OWpMfhPH4MH27hZAvWGlT\
-//                                     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACD1xnn\
-//                                     ferKFHD2uvYqTXdDA8iZ22kCD5xw7h38CMfOngAAAAAAAAAA\
-//                                     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
-//                                     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
-//                                     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
-//                                     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
-//                                     AAAAAAAAAADYIY9k0MVmCdIDUuFLf/2bGIHAfPjO9nvC7fgz\
-//                                     rQedeA3WW4dFeI6oe+RCLdV3XYD1n6lEZjITOzPPLWDxulGz",
-//             "id": "53530608302195762335736519878284384788",
-//             "epidPseudonym": "NRksaQej8R/SyyHpZXzQGNBXqfrzPy5KCxcmJrEjupXrq3xrm2y2+J\
-//                               p0IBVtcW15MCekYs9K3UH82fPyj6F5ciJoMsgEMEIvRR+csX9uyd54\
-//                               p+m+/RVyuGYhWbhUcpJigdI5Q3x04GG/A7EP10j/zypwqhYLQh0qN1\
-//                               ykYt1N1P0="
-//         });
-//
-//         report
-//     }
-//
-//     // pub fn run_tests() -> bool {
-//     //     run_tests!(
-//     //         test_sgx_quote_parse_from,
-//     //         test_attestation_report_from_cert,
-//     //         test_attestation_report_from_cert_api_version_not_compatible
-//     //     )
-//     // }
-//
-//     fn test_sgx_quote_parse_from() {
-//         let attn_report = attesation_report();
-//         let sgx_quote_body_encoded = attn_report["isvEnclaveQuoteBody"].as_str().unwrap();
-//         let quote_raw = base64::decode(&sgx_quote_body_encoded.as_bytes()).unwrap();
-//         let sgx_quote = SgxQuote::parse_from(quote_raw.as_slice()).unwrap();
-//
-//         assert_eq!(
-//             sgx_quote.version,
-//             SgxQuoteVersion::V2(SgxEpidQuoteSigType::Linkable)
-//         );
-//         assert_eq!(sgx_quote.gid, 2863);
-//         assert_eq!(sgx_quote.isv_svn_qe, 10);
-//         assert_eq!(sgx_quote.isv_svn_pce, 9);
-//         assert_eq!(
-//             sgx_quote.qe_vendor_id,
-//             Uuid::parse_str("00000000-ad73-4503-88a6-77623f822196").unwrap()
-//         );
-//         assert_eq!(
-//             sgx_quote.user_data,
-//             [117, 182, 2, 76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-//         );
-//
-//         let isv_enclave_report = sgx_quote.isv_enclave_report;
-//         assert_eq!(
-//             isv_enclave_report.cpu_svn,
-//             [5, 14, 2, 5, 255, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-//         );
-//         assert_eq!(isv_enclave_report.misc_select, 0);
-//         assert_eq!(
-//             isv_enclave_report.attributes,
-//             [7, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0]
-//         );
-//         assert_eq!(
-//             isv_enclave_report.mr_enclave,
-//             [
-//                 51, 10, 169, 16, 163, 119, 103, 128, 226, 0, 38, 174, 61, 172, 7, 175, 14, 90, 147,
-//                 31, 132, 241, 248, 48, 125, 187, 133, 144, 47, 88, 105, 83
-//             ]
-//         );
-//         assert_eq!(
-//             isv_enclave_report.mr_signer,
-//             [
-//                 131, 215, 25, 231, 125, 234, 202, 20, 112, 246, 186, 246, 42, 77, 119, 67, 3, 200,
-//                 153, 219, 105, 2, 15, 156, 112, 238, 29, 252, 8, 199, 206, 158
-//             ]
-//         );
-//         assert_eq!(isv_enclave_report.isv_prod_id, 0);
-//         assert_eq!(isv_enclave_report.isv_svn, 0);
-//         assert_eq!(
-//             isv_enclave_report.report_data.to_vec(),
-//             [
-//                 216, 33, 143, 100, 208, 197, 102, 9, 210, 3, 82, 225, 75, 127, 253, 155, 24, 129,
-//                 192, 124, 248, 206, 246, 123, 194, 237, 248, 51, 173, 7, 157, 120, 13, 214, 91,
-//                 135, 69, 120, 142, 168, 123, 228, 66, 45, 213, 119, 93, 128, 245, 159, 169, 68,
-//                 102, 50, 19, 59, 51, 207, 45, 96, 241, 186, 81, 179
-//             ]
-//             .to_vec()
-//         );
-//     }
-//
-//     fn test_attestation_report_from_cert() {
-//         let tls_ra_cert = tls_ra_cert_der_v4();
-//         let report = AttestationReport::from_cert(&tls_ra_cert);
-//         assert!(report.is_ok());
-//
-//         let report = report.unwrap();
-//         assert_eq!(report.sgx_quote_status, SgxQuoteStatus::GroupOutOfDate);
-//     }
-//
-//     fn test_attestation_report_from_cert_api_version_not_compatible() {
-//         let tls_ra_cert = tls_ra_cert_der_v3();
-//         let report = AttestationReport::from_cert(&tls_ra_cert);
-//         assert!(report.is_err());
-//     }
-// }
+#[cfg(feature = "test")]
+pub mod tests {
+    use serde_json::json;
+    use std::io::Read;
+    use std::untrusted::fs::File;
+
+    use super::*;
+
+    fn tls_ra_cert_der_v3() -> Vec<u8> {
+        let mut cert = vec![];
+        let mut f = File::open("fixtures/tls_ra_cert_v3.der").unwrap();
+        f.read_to_end(&mut cert).unwrap();
+
+        cert
+    }
+
+    fn tls_ra_cert_der_v4() -> Vec<u8> {
+        let mut cert = vec![];
+        let mut f = File::open("fixtures/tls_ra_cert_v4.der").unwrap();
+        f.read_to_end(&mut cert).unwrap();
+
+        cert
+    }
+
+    fn ias_root_ca_cert_der() -> Vec<u8> {
+        let mut cert = vec![];
+        let mut f = File::open("fixtures/ias_root_ca_cert.der").unwrap();
+        f.read_to_end(&mut cert).unwrap();
+
+        cert
+    }
+
+    fn attesation_report() -> Value {
+        let report = json!({
+            "version": 3,
+            "timestamp": "2020-02-11T22:25:59.682915",
+            "platformInfoBlob": "1502006504000900000D0D02040180030000000000000000000\
+                                 A00000B000000020000000000000B2FE0AE0F7FD4D552BF7EF4\
+                                 C938D44E349F1BD0E76F041362DC52B43B7B25994978D792137\
+                                 90362F6DAE91797ACF5BD5072E45F9A60795D1FFB10140421D8\
+                                 691FFD",
+            "isvEnclaveQuoteStatus": "GROUP_OUT_OF_DATE",
+            "isvEnclaveQuoteBody": "AgABAC8LAAAKAAkAAAAAAK1zRQOIpndiP4IhlnW2AkwAAAAA\
+                                    AAAAAAAAAAAAAAAABQ4CBf+AAAAAAAAAAAAAAAAAAAAAAAAA\
+                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAA\
+                                    AAAAADMKqRCjd2eA4gAmrj2sB68OWpMfhPH4MH27hZAvWGlT\
+                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACD1xnn\
+                                    ferKFHD2uvYqTXdDA8iZ22kCD5xw7h38CMfOngAAAAAAAAAA\
+                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+                                    AAAAAAAAAADYIY9k0MVmCdIDUuFLf/2bGIHAfPjO9nvC7fgz\
+                                    rQedeA3WW4dFeI6oe+RCLdV3XYD1n6lEZjITOzPPLWDxulGz",
+            "id": "53530608302195762335736519878284384788",
+            "epidPseudonym": "NRksaQej8R/SyyHpZXzQGNBXqfrzPy5KCxcmJrEjupXrq3xrm2y2+J\
+                              p0IBVtcW15MCekYs9K3UH82fPyj6F5ciJoMsgEMEIvRR+csX9uyd54\
+                              p+m+/RVyuGYhWbhUcpJigdI5Q3x04GG/A7EP10j/zypwqhYLQh0qN1\
+                              ykYt1N1P0="
+        });
+
+        report
+    }
+
+    // pub fn run_tests() -> bool {
+    //     run_tests!(
+    //         test_sgx_quote_parse_from,
+    //         test_attestation_report_from_cert,
+    //         test_attestation_report_from_cert_api_version_not_compatible
+    //     )
+    // }
+
+    fn test_sgx_quote_parse_from() {
+        let attn_report = attesation_report();
+        let sgx_quote_body_encoded = attn_report["isvEnclaveQuoteBody"].as_str().unwrap();
+        let quote_raw = base64::decode(&sgx_quote_body_encoded.as_bytes()).unwrap();
+        let sgx_quote = SgxQuote::parse_from(quote_raw.as_slice()).unwrap();
+
+        assert_eq!(
+            sgx_quote.version,
+            SgxQuoteVersion::V2(SgxEpidQuoteSigType::Linkable)
+        );
+        assert_eq!(sgx_quote.gid, 2863);
+        assert_eq!(sgx_quote.isv_svn_qe, 10);
+        assert_eq!(sgx_quote.isv_svn_pce, 9);
+        assert_eq!(
+            sgx_quote.qe_vendor_id,
+            Uuid::parse_str("00000000-ad73-4503-88a6-77623f822196").unwrap()
+        );
+        assert_eq!(
+            sgx_quote.user_data,
+            [117, 182, 2, 76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+
+        let isv_enclave_report = sgx_quote.isv_enclave_report;
+        assert_eq!(
+            isv_enclave_report.cpu_svn,
+            [5, 14, 2, 5, 255, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+        assert_eq!(isv_enclave_report.misc_select, 0);
+        assert_eq!(
+            isv_enclave_report.attributes,
+            [7, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0]
+        );
+        assert_eq!(
+            isv_enclave_report.mr_enclave,
+            [
+                51, 10, 169, 16, 163, 119, 103, 128, 226, 0, 38, 174, 61, 172, 7, 175, 14, 90, 147,
+                31, 132, 241, 248, 48, 125, 187, 133, 144, 47, 88, 105, 83
+            ]
+        );
+        assert_eq!(
+            isv_enclave_report.mr_signer,
+            [
+                131, 215, 25, 231, 125, 234, 202, 20, 112, 246, 186, 246, 42, 77, 119, 67, 3, 200,
+                153, 219, 105, 2, 15, 156, 112, 238, 29, 252, 8, 199, 206, 158
+            ]
+        );
+        assert_eq!(isv_enclave_report.isv_prod_id, 0);
+        assert_eq!(isv_enclave_report.isv_svn, 0);
+        assert_eq!(
+            isv_enclave_report.report_data.to_vec(),
+            [
+                216, 33, 143, 100, 208, 197, 102, 9, 210, 3, 82, 225, 75, 127, 253, 155, 24, 129,
+                192, 124, 248, 206, 246, 123, 194, 237, 248, 51, 173, 7, 157, 120, 13, 214, 91,
+                135, 69, 120, 142, 168, 123, 228, 66, 45, 213, 119, 93, 128, 245, 159, 169, 68,
+                102, 50, 19, 59, 51, 207, 45, 96, 241, 186, 81, 179
+            ]
+            .to_vec()
+        );
+    }
+
+    fn test_attestation_report_from_cert() {
+        let tls_ra_cert = tls_ra_cert_der_v4();
+        let report = AttestationReport::from_cert(&tls_ra_cert);
+        assert!(report.is_ok());
+
+        let report = report.unwrap();
+        assert_eq!(report.sgx_quote_status, SgxQuoteStatus::GroupOutOfDate);
+    }
+
+    fn test_attestation_report_from_cert_api_version_not_compatible() {
+        let tls_ra_cert = tls_ra_cert_der_v3();
+        let report = AttestationReport::from_cert(&tls_ra_cert);
+        assert!(report.is_err());
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/tests.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/tests.rs
@@ -5,7 +5,14 @@ pub extern "C" fn ecall_run_tests() {
 }
 
 #[cfg(feature = "test")]
-#[no_mangle]
-pub extern "C" fn ecall_run_tests() {
-    println!("Running tests!");
+mod tests {
+
+    #[no_mangle]
+    pub extern "C" fn ecall_run_tests() {
+        println!("Running tests!");
+
+        // crate::registration::tests::run_tests();
+        crate::crypto::tests::run_tests();
+        crate::wasm::tests::run_tests();
+    }
 }

--- a/cosmwasm/packages/wasmi-runtime/src/tests.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/tests.rs
@@ -1,0 +1,11 @@
+#[cfg(not(feature = "test"))]
+#[no_mangle]
+pub extern "C" fn ecall_run_tests() {
+    println!("This enclave was not built for running tests.");
+}
+
+#[cfg(feature = "test")]
+#[no_mangle]
+pub extern "C" fn ecall_run_tests() {
+    println!("Running tests!");
+}

--- a/cosmwasm/packages/wasmi-runtime/src/wasm/mod.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/wasm/mod.rs
@@ -9,3 +9,12 @@ mod runtime;
 mod types;
 
 pub use contract_operations::{handle, init, query};
+
+#[cfg(feature = "test")]
+pub mod tests {
+    use super::*;
+    pub fn run_tests() {
+        types::tests::test_new_from_slice();
+        // types::tests::test_msg_decrypt();
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/wasm/types.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/wasm/types.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 pub type IoNonce = [u8; 32];
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct SecretMessage {
     pub nonce: IoNonce,
     pub user_public_key: Ed25519PublicKey,
@@ -107,10 +107,10 @@ impl SecretMessage {
 pub mod tests {
 
     use super::*;
-    use crate::crypto::{key_manager, AESKey, SIVEncryptable, Seed};
+    use crate::crypto::{AESKey, SIVEncryptable, Seed, KEY_MANAGER};
 
     // todo: fix test vectors to actually work
-    fn test_new_from_slice() {
+    pub fn test_new_from_slice() {
         let nonce = [0u8; 32];
         let user_public_key = [0u8; 32];
         let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
@@ -125,35 +125,36 @@ pub mod tests {
             msg: msg.as_bytes().to_vec(),
         };
 
-        let msg_from_slice = SecretMessage::from_slice(&slice);
+        let msg_from_slice = SecretMessage::from_slice(&slice).unwrap();
 
         assert_eq!(secret_msg, msg_from_slice);
     }
 
-    // todo: fix test vectors to actually work
-    fn test_msg_decrypt() {
-        let seed = Seed::new()?;
-
-        if let Err(e) = key_manager.set_consensus_seed(seed) {
-            fail!("Failed to set seed")
-        }
-
-        let nonce = [0u8; 32];
-        let user_public_key = [0u8; 32];
-
-        let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
-        let ket = calc_encryption_key(&nonce, &user_public_key);
-
-        let encrypted_msg = key.encrypt_siv(msg.as_bytes(), &[&[]]);
-
-        let secret_msg = SecretMessage {
-            nonce,
-            user_public_key,
-            msg: encrypted_msg,
-        };
-
-        let decrypted_msg = secret_msg.decrypt()?;
-
-        assert_eq!(decrypted_msg, msg)
-    }
+    // This is commented out because it's trying to modify KEY_MANAGER which is immutable.
+    // // todo: fix test vectors to actually work
+    // pub fn test_msg_decrypt() {
+    //     let seed = Seed::new().unwrap();
+    //
+    //     KEY_MANAGER
+    //         .set_consensus_seed(seed)
+    //         .expect("Failed to set seed");
+    //
+    //     let nonce = [0u8; 32];
+    //     let user_public_key = [0u8; 32];
+    //
+    //     let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
+    //     let key = calc_encryption_key(&nonce, &user_public_key);
+    //
+    //     let encrypted_msg = key.encrypt_siv(msg.as_bytes(), &[&[]]);
+    //
+    //     let secret_msg = SecretMessage {
+    //         nonce,
+    //         user_public_key,
+    //         msg: encrypted_msg,
+    //     };
+    //
+    //     let decrypted_msg = secret_msg.decrypt()?;
+    //
+    //     assert_eq!(decrypted_msg, msg)
+    // }
 }

--- a/cosmwasm/packages/wasmi-runtime/src/wasm/types.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/wasm/types.rs
@@ -103,57 +103,57 @@ impl SecretMessage {
     }
 }
 
-// #[cfg(feature = "test")]
-// pub mod tests {
-//
-//     use super::*;
-//     use crate::crypto::{key_manager, AESKey, SIVEncryptable, Seed};
-//
-//     // todo: fix test vectors to actually work
-//     fn test_new_from_slice() {
-//         let nonce = [0u8; 32];
-//         let user_public_key = [0u8; 32];
-//         let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
-//
-//         let mut slice = nonce.to_vec();
-//         slice.extend_from_slice(&user_public_key);
-//         slice.extend_from_slice(msg.as_bytes());
-//
-//         let secret_msg = SecretMessage {
-//             nonce,
-//             user_public_key,
-//             msg: msg.as_bytes().to_vec(),
-//         };
-//
-//         let msg_from_slice = SecretMessage::from_slice(&slice);
-//
-//         assert_eq!(secret_msg, msg_from_slice);
-//     }
-//
-//     // todo: fix test vectors to actually work
-//     fn test_msg_decrypt() {
-//         let seed = Seed::new()?;
-//
-//         if let Err(e) = key_manager.set_consensus_seed(seed) {
-//             fail!("Failed to set seed")
-//         }
-//
-//         let nonce = [0u8; 32];
-//         let user_public_key = [0u8; 32];
-//
-//         let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
-//         let ket = calc_encryption_key(&nonce, &user_public_key);
-//
-//         let encrypted_msg = key.encrypt_siv(msg.as_bytes(), &[&[]]);
-//
-//         let secret_msg = SecretMessage {
-//             nonce,
-//             user_public_key,
-//             msg: encrypted_msg,
-//         };
-//
-//         let decrypted_msg = secret_msg.decrypt()?;
-//
-//         assert_eq!(decrypted_msg, msg)
-//     }
-// }
+#[cfg(feature = "test")]
+pub mod tests {
+
+    use super::*;
+    use crate::crypto::{key_manager, AESKey, SIVEncryptable, Seed};
+
+    // todo: fix test vectors to actually work
+    fn test_new_from_slice() {
+        let nonce = [0u8; 32];
+        let user_public_key = [0u8; 32];
+        let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
+
+        let mut slice = nonce.to_vec();
+        slice.extend_from_slice(&user_public_key);
+        slice.extend_from_slice(msg.as_bytes());
+
+        let secret_msg = SecretMessage {
+            nonce,
+            user_public_key,
+            msg: msg.as_bytes().to_vec(),
+        };
+
+        let msg_from_slice = SecretMessage::from_slice(&slice);
+
+        assert_eq!(secret_msg, msg_from_slice);
+    }
+
+    // todo: fix test vectors to actually work
+    fn test_msg_decrypt() {
+        let seed = Seed::new()?;
+
+        if let Err(e) = key_manager.set_consensus_seed(seed) {
+            fail!("Failed to set seed")
+        }
+
+        let nonce = [0u8; 32];
+        let user_public_key = [0u8; 32];
+
+        let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
+        let ket = calc_encryption_key(&nonce, &user_public_key);
+
+        let encrypted_msg = key.encrypt_siv(msg.as_bytes(), &[&[]]);
+
+        let secret_msg = SecretMessage {
+            nonce,
+            user_public_key,
+            msg: encrypted_msg,
+        };
+
+        let decrypted_msg = secret_msg.decrypt()?;
+
+        assert_eq!(decrypted_msg, msg)
+    }
+}

--- a/cosmwasm/packages/wasmi-runtime/src/wasm/types.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/wasm/types.rs
@@ -103,57 +103,57 @@ impl SecretMessage {
     }
 }
 
-#[cfg(feature = "test")]
-pub mod tests {
-
-    use super::*;
-    use crate::crypto::{key_manager, AESKey, SIVEncryptable, Seed};
-
-    // todo: fix test vectors to actually work
-    fn test_new_from_slice() {
-        let nonce = [0u8; 32];
-        let user_public_key = [0u8; 32];
-        let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
-
-        let mut slice = nonce.to_vec();
-        slice.extend_from_slice(&user_public_key);
-        slice.extend_from_slice(msg.as_bytes());
-
-        let secret_msg = SecretMessage {
-            nonce,
-            user_public_key,
-            msg: msg.as_bytes().to_vec(),
-        };
-
-        let msg_from_slice = SecretMessage::from_slice(&slice);
-
-        assert_eq!(secret_msg, msg_from_slice);
-    }
-
-    // todo: fix test vectors to actually work
-    fn test_msg_decrypt() {
-        let seed = Seed::new()?;
-
-        if let Err(e) = key_manager.set_consensus_seed(seed) {
-            fail!("Failed to set seed")
-        }
-
-        let nonce = [0u8; 32];
-        let user_public_key = [0u8; 32];
-
-        let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
-        let ket = calc_encryption_key(&nonce, &user_public_key);
-
-        let encrypted_msg = key.encrypt_siv(msg.as_bytes(), &[&[]]);
-
-        let secret_msg = SecretMessage {
-            nonce,
-            user_public_key,
-            msg: encrypted_msg,
-        };
-
-        let decrypted_msg = secret_msg.decrypt()?;
-
-        assert_eq!(decrypted_msg, msg)
-    }
-}
+// #[cfg(feature = "test")]
+// pub mod tests {
+//
+//     use super::*;
+//     use crate::crypto::{key_manager, AESKey, SIVEncryptable, Seed};
+//
+//     // todo: fix test vectors to actually work
+//     fn test_new_from_slice() {
+//         let nonce = [0u8; 32];
+//         let user_public_key = [0u8; 32];
+//         let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
+//
+//         let mut slice = nonce.to_vec();
+//         slice.extend_from_slice(&user_public_key);
+//         slice.extend_from_slice(msg.as_bytes());
+//
+//         let secret_msg = SecretMessage {
+//             nonce,
+//             user_public_key,
+//             msg: msg.as_bytes().to_vec(),
+//         };
+//
+//         let msg_from_slice = SecretMessage::from_slice(&slice);
+//
+//         assert_eq!(secret_msg, msg_from_slice);
+//     }
+//
+//     // todo: fix test vectors to actually work
+//     fn test_msg_decrypt() {
+//         let seed = Seed::new()?;
+//
+//         if let Err(e) = key_manager.set_consensus_seed(seed) {
+//             fail!("Failed to set seed")
+//         }
+//
+//         let nonce = [0u8; 32];
+//         let user_public_key = [0u8; 32];
+//
+//         let msg = "{\"ok\": \"{\"balance\": \"108\"}\"}";
+//         let ket = calc_encryption_key(&nonce, &user_public_key);
+//
+//         let encrypted_msg = key.encrypt_siv(msg.as_bytes(), &[&[]]);
+//
+//         let secret_msg = SecretMessage {
+//             nonce,
+//             user_public_key,
+//             msg: encrypted_msg,
+//         };
+//
+//         let decrypted_msg = secret_msg.decrypt()?;
+//
+//         assert_eq!(decrypted_msg, msg)
+//     }
+// }

--- a/go-cosmwasm/Cargo.toml
+++ b/go-cosmwasm/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [".circleci/*", ".gitignore"]
 
 [lib]
 #crate-type = ["staticlib"]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [[example]]
 name = "muslc"
@@ -26,6 +26,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["backtraces"]
 backtraces = ["snafu/backtraces"]
+enclave-tests = ["cosmwasm-sgx-vm/enclave-tests"]
 
 [dependencies]
 cosmwasm-std = { path = "../cosmwasm/packages/std", features = ["iterator"] }

--- a/go-cosmwasm/Makefile
+++ b/go-cosmwasm/Makefile
@@ -59,7 +59,6 @@ build-rust: librust_cosmwasm_enclave.signed.so lib/libEnclave_u.a
 	@ #this pulls out ELF symbols, 80% size reduction!
 
 librust_cosmwasm_enclave.signed.so: build-enclave
-	cp ../cosmwasm/packages/wasmi-runtime/librust_cosmwasm_enclave.signed.so ./
 
 # This file will be picked up by the crates build script and linked into the library.
 # We make sure that the enclave is built before we compile the edl,
@@ -79,9 +78,26 @@ target/headers/enclave-ffi-types.h: build-enclave
 	mkdir -p $(dir $@)
 	cp ../cosmwasm/packages/wasmi-runtime/$(@) $@
 
+.PHONY: copy-enclave
+copy-enclave:
+	cp ../cosmwasm/packages/wasmi-runtime/librust_cosmwasm_enclave.signed.so ./
+
 .PHONY: build-enclave
 build-enclave:
 	$(MAKE) -C $(Enclave_Path) enclave
+	$(MAKE) copy-enclave
+
+.PHONY: build-test-enclave
+build-test-enclave:
+	FEATURES="test" $(MAKE) -C $(Enclave_Path) enclave
+	mkdir -p target/headers
+	cp ../cosmwasm/packages/wasmi-runtime/target/headers/enclave-ffi-types.h target/headers/enclave-ffi-types.h
+	cp ../cosmwasm/packages/wasmi-runtime/librust_cosmwasm_enclave.signed.so ./
+	sgx_edger8r --untrusted $(Enclave_Path)/Enclave.edl --search-path $(SGX_SDK)/include --search-path $(CUSTOM_EDL_PATH) --untrusted-dir ./
+	$(CC) $(App_C_Flags) -c Enclave_u.c -o Enclave_u.o
+	rm Enclave_u.c
+	mkdir -p lib
+	$(AR) rcsD lib/libEnclave_u.a Enclave_u.o
 
 # implement stripping based on os
 ifeq ($(DLL_EXT),so)
@@ -97,6 +113,10 @@ build-go:
 
 test:
 	RUST_BACKTRACE=1 go test -v ./api ./types .
+
+.PHONY: enclave-tests
+enclave-tests: build-test-enclave
+	RUST_BACKTRACE=1 cargo test --features="enclave-tests" enclave -- --nocapture
 
 # we should build all the docker images locally ONCE and publish them
 docker-image-centos7:

--- a/go-cosmwasm/src/enclave_tests.rs
+++ b/go-cosmwasm/src/enclave_tests.rs
@@ -1,0 +1,1 @@
+pub use cosmwasm_sgx_vm::enclave_tests::*;

--- a/go-cosmwasm/src/lib.rs
+++ b/go-cosmwasm/src/lib.rs
@@ -6,6 +6,9 @@ mod iterator;
 mod memory;
 mod querier;
 
+#[cfg(feature = "enclave-tests")]
+pub mod enclave_tests;
+
 pub use api::GoApi;
 pub use db::{db_t, DB};
 pub use memory::{free_rust, Buffer};

--- a/go-cosmwasm/tests/enclave.rs
+++ b/go-cosmwasm/tests/enclave.rs
@@ -1,0 +1,21 @@
+//! This file is a wrapper for tests running in the enclave.
+use go_cosmwasm::enclave_tests::{ecall_run_tests, get_enclave, sgx_types::sgx_status_t};
+
+/// Safe wrapper for `ecall_run_tests`.
+///
+/// I wanted to define this function in `cosmwasm-sgx-vm` but for some reason it kept complaining
+/// that `ecall_run_tests` was not defined...
+pub fn run_tests() -> sgx_status_t {
+    let enclave = match get_enclave() {
+        Ok(enclave) => enclave,
+        Err(status) => return status,
+    };
+    unsafe { ecall_run_tests(enclave.geteid()) }
+}
+
+#[test]
+fn test_enclave() {
+    let status = run_tests();
+    println!();
+    println!("Enclave returned {}", status);
+}


### PR DESCRIPTION
This PR adds support for writing tests in wasmi-runtime that will run inside a real SGX enclave.
I add two make commands:
- from the project directory: `make enclave-tests` - runs the test suite
- from the wasmi-runtime directory: `make check-enclave-tests` to run the `cargo check` on the test code.

I laid things out as follows:
- An ecall called `ecall_run_tests` is always exported from the enclave.
    - When compiled with the `test` flag, this ecall will run the test suite. When compiled without it, it does nothing
    - functions called by this mechanim should be annotated with `#[cfg(feature = "test")]` or be placed in a module annotated with it.
- This ecall just calls all the tests that it wants to run, one after the other.
- I show a couple examples of how submodules can help organize the test code
- `cosmwasm-sgx-vm` expects the ecall to exist when compiled with the `enclave-tests` flag
- `go-cosmwasm` has an integration test called `enclave` that tries to use this function.

the `make enclave-tests` command runs:
```
cargo test --features="enclave-tests" enclave -- --nocapture
```
from the `go-cosmwasm` directory after compiling the enclave with the `test` flag.