### PR TITLE
removed the custom `WasmEngineError::clone`

### DIFF
--- a/cosmwasm/packages/wasmi-runtime/Cargo.lock
+++ b/cosmwasm/packages/wasmi-runtime/Cargo.lock
@@ -237,6 +237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,8 +768,9 @@ checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 [[package]]
 name = "wasmi"
 version = "0.6.2"
-source = "git+https://github.com/paritytech/wasmi?rev=39a18a433a765a36383d34d4edd536ba1e0664d2#39a18a433a765a36383d34d4edd536ba1e0664d2"
+source = "git+https://github.com/paritytech/wasmi?rev=84d2764594d80425373bf4949a58fa3df3d624c3#84d2764594d80425373bf4949a58fa3df3d624c3"
 dependencies = [
+ "downcast-rs",
  "libm",
  "memory_units",
  "num-rational 0.2.4",
@@ -816,7 +823,7 @@ dependencies = [
 [[package]]
 name = "wasmi-validation"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/wasmi?rev=39a18a433a765a36383d34d4edd536ba1e0664d2#39a18a433a765a36383d34d4edd536ba1e0664d2"
+source = "git+https://github.com/paritytech/wasmi?rev=84d2764594d80425373bf4949a58fa3df3d624c3#84d2764594d80425373bf4949a58fa3df3d624c3"
 dependencies = [
  "parity-wasm",
 ]

--- a/cosmwasm/packages/wasmi-runtime/Cargo.toml
+++ b/cosmwasm/packages/wasmi-runtime/Cargo.toml
@@ -33,7 +33,7 @@ aes-siv = { version = "0.2.0" }
 enclave-ffi-types = { path = "../enclave-ffi-types" }
 pwasm-utils = { version = "0.12.0", default-features = false }
 parity-wasm = { version = "0.41.0", default-features = false }
-wasmi = { git = "https://github.com/paritytech/wasmi", rev = "39a18a433a765a36383d34d4edd536ba1e0664d2", default-features = false, features = [
+wasmi = { git = "https://github.com/paritytech/wasmi", rev = "84d2764594d80425373bf4949a58fa3df3d624c3", default-features = false, features = [
     "core"
 ] }
 serde = { git = "https://github.com/mesalock-linux/serde-sgx", features = [

--- a/cosmwasm/packages/wasmi-runtime/src/wasm/errors.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/wasm/errors.rs
@@ -24,30 +24,6 @@ pub enum WasmEngineError {
     NotImplemented,
 }
 
-impl WasmEngineError {
-    /// This function is unsafe because you have to make sure you do not use the `WasmEngineError`
-    /// instance again after calling this function.
-    unsafe fn clone(&self) -> Self {
-        use WasmEngineError::*;
-        match self {
-            FailedOcall(UntrustedVmError { ptr }) => FailedOcall(UntrustedVmError { ptr: *ptr }),
-            OutOfGas => OutOfGas,
-            Panic => Panic,
-
-            EncryptionError => EncryptionError,
-            DecryptionError => DecryptionError,
-
-            MemoryAllocationError => MemoryAllocationError,
-            MemoryReadError => MemoryReadError,
-            MemoryWriteError => MemoryWriteError,
-            UnauthorizedWrite => UnauthorizedWrite,
-
-            NonExistentImportFunction => NonExistentImportFunction,
-            NotImplemented => NotImplemented,
-        }
-    }
-}
-
 impl HostError for WasmEngineError {}
 
 impl From<WasmEngineError> for EnclaveError {
@@ -71,28 +47,32 @@ impl From<WasmEngineError> for EnclaveError {
     }
 }
 
-pub fn wasmi_error_to_enclave_error(wasmi_error: InterpreterError) -> EnclaveError {
-    match wasmi_error
-        .as_host_error()
-        .map(|err| err.downcast_ref::<WasmEngineError>())
-    {
-        // Safety: This code is safe because we will not use engine_err ever again.
-        // It is dropped at the end of this function.
-        Some(Some(engine_err)) => EnclaveError::from(unsafe { engine_err.clone() }),
-        // Unexpected HostError.
-        Some(None) => EnclaveError::Unknown,
-        // The error is not a HostError.
-        None => {
-            error!("Got an error from wasmi: {:?}", wasmi_error);
-            match wasmi_error {
-                InterpreterError::Trap(trap) => trap_kind_to_enclave_error(trap.kind()),
-                _ => EnclaveError::FailedFunctionCall,
-            }
-        }
+// This is implemented just to make a `Result::map` invocation below nicer.
+// All this does is unbox the `WasmEngineError` and call the `From` implementation above.
+impl From<Box<WasmEngineError>> for EnclaveError {
+    fn from(engine_err: Box<WasmEngineError>) -> Self {
+        Self::from(*engine_err)
     }
 }
 
-fn trap_kind_to_enclave_error(kind: &TrapKind) -> EnclaveError {
+pub fn wasmi_error_to_enclave_error(wasmi_error: InterpreterError) -> EnclaveError {
+    wasmi_error
+        .try_into_host_error()
+        .map(|host_error| {
+            host_error
+                .downcast::<WasmEngineError>()
+                .map_or(EnclaveError::Unknown, EnclaveError::from)
+        })
+        .unwrap_or_else(|wasmi_error| {
+            error!("Got an error from wasmi: {:?}", wasmi_error);
+            match wasmi_error {
+                InterpreterError::Trap(trap) => trap_kind_to_enclave_error(trap.into_kind()),
+                _ => EnclaveError::FailedFunctionCall,
+            }
+        })
+}
+
+fn trap_kind_to_enclave_error(kind: TrapKind) -> EnclaveError {
     match kind {
         TrapKind::Unreachable => EnclaveError::ContractPanicUnreachable,
         TrapKind::MemoryAccessOutOfBounds => EnclaveError::ContractPanicMemoryAccessOutOfBounds,


### PR DESCRIPTION
This PR removes the custom and unsafe  `WasmEngineError::clone` implementation, thus removing some unnecessary unsafe code from our codebase.
We needed this method because of a missing feature in `wasmi::Error` which is now implemented in the latest `master` commit.
(You could only get a reference to your `impl HostError` type, but you couldn't get it by value.)