### PR TITLE
added allocation stack to help validate EnclaveBuffers returned from …

### DIFF
--- a/cosmwasm/packages/enclave-ffi-types/src/types.rs
+++ b/cosmwasm/packages/enclave-ffi-types/src/types.rs
@@ -23,6 +23,9 @@ impl EnclaveBuffer {
     }
 }
 
+/// This is safe because `Vec<u8>`s are `Send`
+unsafe impl Send for EnclaveBuffer {}
+
 impl Default for EnclaveBuffer {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
This should close the last problems presented in #133. 
One question remains - if the pointer is not recognized, should we return `None` (current implementation, represents a valid, empty response), Or should we return some kind of `EnclaveError`, and fail, because something is wrong or the host is trying to mess with us?
CC: @assafmo 