### PR TITLE
Update join-validator-mainnet.md

### DIFF
--- a/docs/validators-and-full-nodes/join-validator-mainnet.md
+++ b/docs/validators-and-full-nodes/join-validator-mainnet.md
@@ -64,6 +64,7 @@ secretcli tx staking create-validator \
   --commission-max-rate="0.20" \
   --commission-max-change-rate="0.01" \
   --min-self-delegation="1" \
+  --gas-prices="0.1uscrt" \
   --moniker=<MONIKER> \
   --from=<key-alias>
 ```


### PR DESCRIPTION
There is nothing telling users how to set gas or where to set it and all transactions will fail unless this is set right.