### PR TITLE
make cosmwasm-storage's dependency on cosmwasm-std more flexible

### DIFF
--- a/cosmwasm/packages/storage/Cargo.toml
+++ b/cosmwasm/packages/storage/Cargo.toml
@@ -19,7 +19,7 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "0.10.0" }
+cosmwasm-std = { path = "../std" }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 
 [dev-dependencies]


### PR DESCRIPTION
I think that our fork of `cosmwasm-storage` at `v1.0.0` is broken... trying to see if this fixes it.
