### PR TITLE
Fix trust_node=false issue

### DIFF
--- a/cmd/secretcli/secret20.go
+++ b/cmd/secretcli/secret20.go
@@ -108,7 +108,7 @@ func S20TransferHistoryCmd(cdc *codec.Codec) *cobra.Command {
 
 			queryData := queryTransferHistoryMsg(addr, key, uint32(page), uint32(pageSize))
 
-			err = cli.QueryWithData(contractAddr, cdc, queryData, cliCtx)
+			err = cli.QueryWithData(contractAddr, cliCtx, queryData)
 			if err != nil {
 				return err
 			}
@@ -148,7 +148,7 @@ key yet, use the "create-viewing-key" command. Otherwise, you can still see your
 
 			queryData := queryBalanceMsg(addr, key)
 
-			err = cli.QueryWithData(contractAddr, cdc, queryData, cliCtx)
+			err = cli.QueryWithData(contractAddr, cliCtx, queryData)
 			if err != nil {
 				return err
 			}

--- a/cmd/secretcli/secret20.go
+++ b/cmd/secretcli/secret20.go
@@ -108,7 +108,7 @@ func S20TransferHistoryCmd(cdc *codec.Codec) *cobra.Command {
 
 			queryData := queryTransferHistoryMsg(addr, key, uint32(page), uint32(pageSize))
 
-			err = cli.QueryWithData(contractAddr, cdc, queryData)
+			err = cli.QueryWithData(contractAddr, cdc, queryData, cliCtx)
 			if err != nil {
 				return err
 			}
@@ -148,7 +148,7 @@ key yet, use the "create-viewing-key" command. Otherwise, you can still see your
 
 			queryData := queryBalanceMsg(addr, key)
 
-			err = cli.QueryWithData(contractAddr, cdc, queryData)
+			err = cli.QueryWithData(contractAddr, cdc, queryData, cliCtx)
 			if err != nil {
 				return err
 			}

--- a/x/compute/client/cli/query.go
+++ b/x/compute/client/cli/query.go
@@ -475,7 +475,7 @@ func GetCmdQuery(cdc *codec.Codec) *cobra.Command {
 				return errors.New("query data must be json")
 			}
 
-			return QueryWithData(contractAddr, cdc, queryData, cliCtx)
+			return QueryWithData(contractAddr, cliCtx, queryData)
 		},
 	}
 	decoder.RegisterFlags(cmd.PersistentFlags(), "query argument")
@@ -483,7 +483,7 @@ func GetCmdQuery(cdc *codec.Codec) *cobra.Command {
 	return cmd
 }
 
-func QueryWithData(contractAddress string, cdc *codec.Codec, queryData []byte, cliCtx context.CLIContext) error {
+func QueryWithData(contractAddress string, cliCtx context.CLIContext, queryData []byte) error {
 	addr, err := sdk.AccAddressFromBech32(contractAddress)
 	if err != nil {
 		return err

--- a/x/compute/client/cli/query.go
+++ b/x/compute/client/cli/query.go
@@ -475,7 +475,7 @@ func GetCmdQuery(cdc *codec.Codec) *cobra.Command {
 				return errors.New("query data must be json")
 			}
 
-			return QueryWithData(contractAddr, cdc, queryData)
+			return QueryWithData(contractAddr, cdc, queryData, cliCtx)
 		},
 	}
 	decoder.RegisterFlags(cmd.PersistentFlags(), "query argument")
@@ -483,9 +483,7 @@ func GetCmdQuery(cdc *codec.Codec) *cobra.Command {
 	return cmd
 }
 
-func QueryWithData(contractAddress string, cdc *codec.Codec, queryData []byte) error {
-	cliCtx := context.NewCLIContext().WithCodec(cdc)
-
+func QueryWithData(contractAddress string, cdc *codec.Codec, queryData []byte, cliCtx context.CLIContext) error {
 	addr, err := sdk.AccAddressFromBech32(contractAddress)
 	if err != nil {
 		return err


### PR DESCRIPTION
`CLIContext` was created twice, so the second context got hit with `resource temporarily unavailable` when accessing leveldb files