### PR TITLE
updates for holodeck-2 testnet and more

### DIFF
--- a/docs/testnet/developing-secret-contracts.md
+++ b/docs/testnet/developing-secret-contracts.md
@@ -1,0 +1,238 @@
+# Developing Secret Contracts
+
+Secret Contacts are based on CosmWasm v0.10.
+
+Check out the [CosmWasm docs](https://docs.cosmwasm.com) as well. They are probably more extensive.
+
+Don't forget to go over the [differences between SecretWasm and CosmWasm](#differences-from-cosmwasm).
+
+- [Developing Secret Contracts](#developing-secret-contracts)
+  - [IDEs](#ides)
+  - [Personal Secret Network for Secret Contract development](#personal-secret-network-for-secret-contract-development)
+  - [Init](#init)
+  - [Handle](#handle)
+  - [Query](#query)
+  - [Inputs](#inputs)
+  - [APIs](#apis)
+  - [State](#state)
+  - [Some libraries/crates considerations](#some-librariescrates-considerations)
+  - [Randomness](#randomness)
+    - [Roll your own](#roll-your-own)
+      - [Poker deck shuffling example](#poker-deck-shuffling-example)
+    - [Use an external oracle](#use-an-external-oracle)
+  - [Outputs](#outputs)
+  - [External query](#external-query)
+  - [Compiling](#compiling)
+    - [With docker](#with-docker)
+    - [Without docker](#without-docker)
+  - [Storing and deploying](#storing-and-deploying)
+  - [Verifying your contract code on explorers](#verifying-your-contract-code-on-explorers)
+  - [Testing](#testing)
+  - [Debugging](#debugging)
+  - [Building secret apps with SecretJS](#building-secret-apps-with-secretjs)
+    - [Wallet integration](#wallet-integration)
+  - [Differences from CosmWasm](#differences-from-cosmwasm)
+
+## IDEs
+
+Secret Contracts are developed with the [Rust](https://www.rust-lang.org/) programming language and compiled to [WASM](https://webassembly.org/) binaries.
+
+These IDEs are known to work very well for developing Secret Contracts:
+
+- [CLion](https://www.jetbrains.com/clion/)
+- [VSCode](https://code.visualstudio.com/) with the [rust-analyzer](https://rust-analyzer.github.io/) extension
+
+## Personal Secret Network for Secret Contract development
+
+The developer blockchain is configured to run inside a docker container. Install [Docker](https://docs.docker.com/install/) for your environment (Mac, Windows, Linux).
+
+Open a terminal window and change to your project directory.
+Then start SecretNetwork, labelled _secretdev_:
+
+```
+$ docker run -it --rm \
+ -p 26657:26657 -p 26656:26656 -p 1317:1317 \
+ --name secretdev enigmampc/secret-network-bootstrap-sw:latest
+```
+
+**NOTE**: The _secretdev_ docker container can be stopped with Ctrl+C
+
+At this point you're running a local SecretNetwork full-node. Let's connect to the container so we can view and manage the secret keys:
+
+**NOTE**: In a new terminal
+
+```
+docker exec -it secretdev /bin/bash
+```
+
+The local blockchain has a couple of keys setup for you (similar to accounts if you're familiar with Truffle Ganache). The keys are stored in the `test` keyring backend, which makes it easier for local development and testing.
+
+```
+secretcli keys list --keyring-backend test
+```
+
+![](../images/images/secretcli_keys_list.png)
+
+`exit` when you are done.
+
+## Init
+
+`init` is the constructor of your contract. This function is called only once in the lifetime of the contract.
+
+Example Invocation from `secretcli`:
+
+```bash
+secretcli tx compute instantiate "$CODE_ID" "$INPUT_MSG" --label "$UNIQUE_LABEL" --from "$MY_KEY"
+```
+
+Example Invocation from `SecretJS`:
+
+```js
+// TODO
+```
+
+## Handle
+
+`handle` is the implementation of execute transactions.
+
+Example Invocation from `secretcli`:
+
+```bash
+secretcli tx compute execute "$CONTRACT_ADDRESS" "$INPUT_ARGS" --from "$MY_KEY" # Option A
+secretcli tx compute execute --label "$LABEL" "$INPUT_ARGS" --from "$MY_KEY"    # Option B
+```
+
+Example Invocation from `SecretJS`:
+
+```js
+// TODO
+```
+
+## Query
+
+`query` is the implementation of read-only queries. Queries run over the current blockchain state but don't incur fees and don't have access to `msg.sender`. They are still metered by a gas limit that is set on the executing node.
+
+Example Invocation from `secretcli`:
+
+```bash
+secretcli q compute query "$CONTRACT_ADDRESS" "$INPUT_ARGS"
+```
+
+Example Invocation from `SecretJS`:
+
+```js
+// TODO
+```
+
+## Inputs
+
+## APIs
+
+## State
+
+## Some libraries/crates considerations
+
+- `bincode2` instead of `bincode` for serializing data.
+- `serde_json_wasm` instead of `serde_json` for serializing data.
+- `bech32` instead of `deps.api.canonical_address` and `deps.api.human_address`, as they only support `secret` prefix (E.g. not `secretvaloper` for staking use-cases).
+
+## Randomness
+
+### Roll your own
+
+#### Poker deck shuffling example
+
+1. When joining a room, [each player sends a secret number](https://github.com/enigmampc/SecretHoldEm/blob/4f67c469bb4a0f53522c7ad069e54ae5c1effb6b/contract/src/contract.rs#L172).
+2. Once the room is full, all secrets are combined with sha256 to [create a random seed](https://github.com/enigmampc/SecretHoldEm/blob/4f67c469bb4a0f53522c7ad069e54ae5c1effb6b/contract/src/contract.rs#L349-L355).
+3. With that seed, the [deck is shuffled](https://github.com/enigmampc/SecretHoldEm/blob/4f67c469bb4a0f53522c7ad069e54ae5c1effb6b/contract/src/contract.rs#L356-L357).
+4. Each round a [game counter is incremented](https://github.com/enigmampc/SecretHoldEm/blob/4f67c469bb4a0f53522c7ad069e54ae5c1effb6b/contract/src/contract.rs#L602-L614), and along with the players' secrets is used to create a new seed for re-shuffling the deck.
+5. On the frondend side, [SecretJS is used to generate a secure random number](https://github.com/enigmampc/SecretHoldEm/blob/4f67c469bb4a0f53522c7ad069e54ae5c1effb6b/gui/src/App.js#L334-L354) and sends it as a secret when a player joins the table. A random number is not really necessary, and every secret number would work just as well.
+6. As long as at least one player is not colluding with the rest, and by properties of sha256, the seeds for shuffling the deck are known only to the contract and to no one else. If all players are colliding, they might as well all play with open hands. :joy:
+
+### Use an external oracle
+
+No implementation exists yet, but it's not that hard to implement.
+
+For example:
+
+1. Have a `handle` function `input_entropy` for users to send entropy in.
+2. `input_entropy` will have a storage key named `seed`.
+3. On each input to `input_entropy`, `seed = hash(seed + input)`.
+4. Have another `handle` function `get_random_number` for users to get a random number.
+5. `get_random_number` must also add to the entropy pool, otherwise consecutive `get_random_number` calls will output the same random number. For example `seed = hash(seed + msg.sender + block.height + ...)`.
+6. `get_random_number` will just return the `hash(seed)` or some other non-reversible derivative of it, and update the `seed` with the new entropy like described in the previous point.
+7. Have `get_random_number` also callback to the caller contract with the random number.
+8. You can even have a cron job to send data from [random.org](https://www.random.org/) to `input_entropy`.
+
+This exmaple has a much worse UX than rolling your own randomness, but at least contracts won't have to rely on users to send entropy and also won't take the risk of messing up the implementation.
+
+## Outputs
+
+## External query
+
+## Compiling
+
+### With docker
+
+```console
+$ docker run --rm -it -v /absolute/path/to/contract/project:/contract enigmampc/secret-contract-optimizer
+```
+
+Where `/absolute/path/to/contract/project` is pointing to the directory that contains your Secret Contract's `Cargo.toml`.
+
+This will output an optimized build file `/absolute/path/to/contract/project/contract.wasm.gz`.
+
+### Without docker
+
+```console
+$ rustup target add wasm32-unknown-unknown
+$ sudo apt install binaryen
+```
+
+```console
+$ RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown --locked
+$ wasm-opt -Oz ./target/wasm32-unknown-unknown/release/*.wasm -o ./contract.wasm
+$ cat ./contract.wasm | gzip -9 > ./contract.wasm.gz
+```
+
+Breakdown:
+
+1. Build a release mode WASM file, strip symbols
+2. Further optimize with [wasm-opt](https://github.com/WebAssembly/binaryen)
+3. Gzip
+
+## Storing and deploying
+
+## Verifying your contract code on explorers
+
+## Testing
+
+## Debugging
+
+## Building secret apps with SecretJS
+
+A Secret App, or a SApp, is a DApp with computational and data privacy.
+A Secret App is usually comprised of the following components:
+
+- A Secret Contract deployed on the Secret Network
+- A frontend app built with a JavaScript framework (E.g. ReactJS, VueJS, AngularJS, etc.)
+- The frontend app connects to the Secret Network using SecretJS,
+- SecretJS interacts with a REST API exposed by nodes in the Secret Network. The REST API/HTTPS server is commonly referred to as LCD Server (Light Client Daemon :shrug:). Usually by connecting SecretJS with a wallet, the wallet handles the interactions with the LCD server.
+
+### Wallet integration
+
+Still not implemented in wallets. Can implement a local wallet but this will probably won't be needed anymore after 2020.
+
+# Differences from CosmWasm
+
+Secret Contacts are based on CosmWasm v0.10, but in order to preserve privacy, they diverge in functionality in some cases.
+
+- `code_hash` in callbacks
+- Can access the current contract's `code_hash` via `env.contract_code_hash`
+- contract labels are unique, thus mandatory on callback to `init`
+- `migrate` and `admin` for contracts is not allowed
+- iterator (`db_scan`, `db_next`) on contract state keys is not allowed
+- `cosmwasm_std` changes...
+- SGX memory limits (30 MiB total, 12 MiB per contract vs 32 MiB per contract)
+- We charge gas for memory allocations, vanilla CosmWasm don't
+- `SecretJS` has a new function - `GenerateNewSeed` to help apps to get a secure 32 byte random number

--- a/docs/testnet/install_cli.md
+++ b/docs/testnet/install_cli.md
@@ -4,22 +4,22 @@
 
 * Linux AMD64
 ```
-https://github.com/enigmampc/SecretNetwork/releases/download/v1.0.2/secretcli-linux-amd64
+https://github.com/enigmampc/SecretNetwork/releases/download/v1.0.3/secretcli-linux-amd64
 ```
 
 * Linux ARM64
 ```
-https://github.com/enigmampc/SecretNetwork/releases/download/v1.0.2/secretcli-linux-arm64
+https://github.com/enigmampc/SecretNetwork/releases/download/v1.0.3/secretcli-linux-arm64
 ```
 
 * MacOS
 ```
-https://github.com/enigmampc/SecretNetwork/releases/download/v1.0.2/secretcli-darwin-10.6-amd64
+https://github.com/enigmampc/SecretNetwork/releases/download/v1.0.3/secretcli-darwin-10.6-amd64
 ```
 
 * Windows
 ```
-https://github.com/enigmampc/SecretNetwork/releases/download/v1.0.2/secretcli-windows-4.0-amd64.exe
+https://github.com/enigmampc/SecretNetwork/releases/download/v1.0.3/secretcli-windows-4.0-amd64.exe
 ```
 
 ## Setup the executable

--- a/docs/testnet/join-validator-testnet.md
+++ b/docs/testnet/join-validator-testnet.md
@@ -22,7 +22,7 @@ secretcli keys add <key-alias>
 ```
 
 **:warning:Note:warning:: Backup the mnemonics!**
-**:warning:Note:warning:: Please make sure you also [backup your validator](../validators-and-full-nodes/backup-a-validator.md)**
+**:warning:Note:warning:: Please make sure you also [backup your validator](backup-a-testnet-validator.md)**
 
 **Note**: If you already have a key you can import it with the bip39 mnemonic with `secretcli keys add <key-alias> --recover` or with `secretcli keys export` (exports to `stderr`!!) & `secretcli keys import`.
 

--- a/docs/testnet/migrate-a-testnet-validator.md
+++ b/docs/testnet/migrate-a-testnet-validator.md
@@ -2,9 +2,9 @@
 
 :warning: :warning: :warning:
 
-Please make sure you [backup your validator](/validators-and-full-nodes/backup-a-validator.md) before you migrate it.
+Please make sure you [backup your validator](run-full-node-testnet.md) before you migrate it.
 
-### 1. [Run a new full node](/validators-and-full-nodes/run-full-node-mainnet.md) on a new machine.
+### 1. [Run a new full node](run-full-node-testnet.md) on a new machine.
 
 ### 2. Confirm you have the recovery seed phrase information for the active key running on the old machine
 

--- a/docs/testnet/registration.md
+++ b/docs/testnet/registration.md
@@ -44,7 +44,7 @@ This feature is refered to as a reproducable build, and is a feature that will b
 
 To register your node, you will need:
 
-* RPC address of an already active node. You can use `bootstrap.pub.testnet.enigma.co:26657`, or any other node that exposes RPC services.
+* RPC address of an already active node. You can use `bootstrap.secrettestnet.io:26657`, or any other node that exposes RPC services.
 
 * Account with some SCRT
 

--- a/docs/testnet/release-notes.md
+++ b/docs/testnet/release-notes.md
@@ -1,8 +1,14 @@
 ## Release notes
 
-## Current Release - v0.8.0
+## Current Release - v1.0.0
 
-Our release candidate. This is running 99% of the code which is going to run in the mainnet release. The primary goal of this version is for node runners and validators 
+- Secret Contracts
+
+## Previous releases
+
+### v0.8.0
+
+Release candidate running 99% of the code which is in the v1.0.0 mainnet release. The primary goal of this version was for node runners and validators 
 to be able to test their setups on a configuration which will mirror the mainnet release.
 
 #### Contracts
@@ -33,8 +39,6 @@ to be able to test their setups on a configuration which will mirror the mainnet
 
 - Made the world a better place
 - Security and stablility fixes
-
-## Previous releases
 
 ### v0.7.0
 

--- a/docs/testnet/run-full-node-docker.md
+++ b/docs/testnet/run-full-node-docker.md
@@ -99,7 +99,7 @@ services:
     tty: true
 
   node:
-    image: enigmampc/secret-network-node:v0.8.1-mainnet
+    image: enigmampc/secret-network-node:v1.0.0-mainnet
     devices:
       - /dev/isgx
     volumes:
@@ -146,14 +146,14 @@ Note: If you delete or lose either the .secretd or the .sgx_secrets folder your 
 ### 5. Set up environment variables
 
 - MONIKER - your network name
-- RPC_URL - address of a node with an open RPC service (you can use `bootstrap.pub.testnet3.enigma.co:26657`)
-- CHAINID - chain-id of the network (for testnet this is `enigma-pub-testnet-4`)
-- PERSISTENT_PEERS - List of peers to connect to initially (for this testnet use `115aa0a629f5d70dd1d464bc7e42799e00f4edae@bootstrap.pub.testnet3.enigma.co:26656`)
-- REGISTRATION_SERVICE - Address of registration service (this will help the node start automatically without going through all the manual steps in the other guide) - `register.pub.testnet.enigma.co:26667`
+- RPC_URL - address of a node with an open RPC service (you can use `bootstrap.secrettestnet.io:26657`)
+- CHAINID - chain-id of the network (for testnet this is `holodeck-2`)
+- PERSISTENT_PEERS - List of peers to connect to initially (for this testnet use `64b03220d97e5dc21ec65bf7ee1d839afb6f7193@bootstrap.secrettestnet.io:26656`)
+- REGISTRATION_SERVICE - Address of registration service (this will help the node start automatically without going through all the manual steps in the other guide) - `bootstrap.secrettestnet.io:26667`
 
 You can set an environment variable using the `export` syntax
 
-`export RPC_URL=bootstrap.pub.testnet3.enigma.co:26657`
+`export RPC_URL=bootstrap.secrettestnet.io:26657`
 
 ### 6. Start your node
 
@@ -165,7 +165,7 @@ After creating the machine a healthy status of the node will have 2 containers a
 
 ```
 CONTAINER ID        IMAGE                                      COMMAND                  CREATED             STATUS                    PORTS                                  NAMES
-bf9ba8dd0802        enigmampc/secret-network-node:v0.8.1-mainnet   "/bin/bash startup.sh"   13 minutes ago      Up 13 minutes (healthy)   0.0.0.0:26656-26657->26656-26657/tcp   secret-node_node_1
+bf9ba8dd0802        enigmampc/secret-network-node:v1.0.0-mainnet   "/bin/bash startup.sh"   13 minutes ago      Up 13 minutes (healthy)   0.0.0.0:26656-26657->26656-26657/tcp   secret-node_node_1
 2405b23aa1bd        cashmaney/aesm                             "/bin/sh -c './aesm_…"   13 minutes ago      Up 13 minutes                                                    secret-node_aesm_1
 ```
 

--- a/docs/testnet/run-full-node-testnet-docker.md
+++ b/docs/testnet/run-full-node-testnet-docker.md
@@ -1,6 +1,6 @@
 # How to join the Secret Network as a full node on mainnet
 
-This document details how to join the Secret Network `mainnet` as a validator.
+This document details how to join the Secret Network `testnet` as a validator.
 
 ## Requirements
 
@@ -8,7 +8,7 @@ This document details how to join the Secret Network `mainnet` as a validator.
 - A public IP address
 - Open ports `TCP 26656 & 26657` _Note: If you're behind a router or firewall then you'll need to port forward on the network device._
 - Reading https://docs.tendermint.com/master/tendermint-core/running-in-production.html
-- RPC address of an already active node. You can use `registration.enigma.co:26657`, or any other node that exposes RPC services.
+- RPC address of an already active node. You can use `bootstrap.secrettestnet.io:26657`, or any other node that exposes RPC services.
 - Account with at least 1 SCRT
 
 ### Minimum requirements

--- a/docs/testnet/run-full-node-testnet.md
+++ b/docs/testnet/run-full-node-testnet.md
@@ -8,7 +8,7 @@ This document details how to join the Secret Network `testnet` as a full node. O
 - A public IP address
 - Open ports `TCP 26656 & 26657` _Note: If you're behind a router or firewall then you'll need to port forward on the network device._
 - Reading https://docs.tendermint.com/master/tendermint-core/running-in-production.html
-- RPC address of an already active node. You can use `bootstrap.pub.testnet3.enigma.co:26657`, or any other node that exposes RPC services.
+- RPC address of an already active node. You can use `bootstrap.secrettestnet.io:26657`, or any other node that exposes RPC services.
 
 ### Minimum requirements
 
@@ -29,12 +29,12 @@ Refer to https://ark.intel.com/content/www/us/en/ark.html#@Processors if unsure 
 
 ### 0. Step up SGX on your local machine
 
-See instructions for [setup](../validators-and-full-nodes/setup-sgx.md) and [verification](verify-sgx.md).
+See instructions for [setup](setup-sgx-testnet.md) and [verification](verify-sgx.md).
 
 ### 1. Download the Secret Network package installer for Debian/Ubuntu:
 
 ```bash
-wget https://github.com/enigmampc/SecretNetwork/releases/download/v0.8.1/secretnetwork_0.8.1_amd64.deb
+wget https://github.com/chainofsecrets/SecretNetwork/releases/download/v1.0.0/secretnetwork_1.0.0_amd64.deb
 ```
 
 ([How to verify releases](../verify-releases.md))
@@ -42,7 +42,7 @@ wget https://github.com/enigmampc/SecretNetwork/releases/download/v0.8.1/secretn
 ### 2. Install the package:
 
 ```bash
-sudo dpkg -i secretnetwork_0.8.1_amd64.deb
+sudo dpkg -i secretnetwork_1.0.0_amd64.deb
 ```
 
 ### 3. Initialize your installation of the Secret Network.
@@ -51,19 +51,19 @@ Choose a **moniker** for yourself, and replace `<MONIKER>` with your moniker bel
 This moniker will serve as your public nickname in the network.
 
 ```bash
-secretd init <MONIKER> --chain-id enigma-pub-testnet-4
+secretd init <MONIKER> --chain-id holodeck-2
 ```
 
 ### 4. Download a copy of the Genesis Block file: `genesis.json`
 
 ```bash
-wget -O ~/.secretd/config/genesis.json "https://github.com/enigmampc/SecretNetwork/releases/download/v0.8.1/genesis.json"
+wget -O ~/.secretd/config/genesis.json "https://github.com/chainofsecrets/SecretNetwork/releases/download/v1.0.0/holodeck-2-genesis.json"
 ```
 
 ### 5. Validate the checksum for the `genesis.json` file you have just downloaded in the previous step:
 
 ```bash
-echo "0ccbe047a8dbdc43ee2f3de74f7a26fc36376aec130b8813ac76a1f95e5a6e8f $HOME/.secretd/config/genesis.json" | sha256sum --check
+echo "e45d6aa9825bae70c277509c8346122e265d64cb4211c23def4ae8f6bf3da2f1 $HOME/.secretd/config/genesis.json" | sha256sum --check
 ```
 
 ### 6. Validate that the `genesis.json` is a valid genesis file:
@@ -122,8 +122,8 @@ To run the steps with `secretcli` on another machine, [set up the CLI](install_c
 Configure `secretcli`. Initially you'll be using the bootstrap node, as you'll need to connect to a running node and your own node is not running yet.
 
 ```bash
-secretcli config chain-id enigma-pub-testnet-4
-secretcli config node tcp://bootstrap.pub.testnet3.enigma.co:26657
+secretcli config chain-id holodeck-2
+secretcli config node tcp://bootstrap.secrettestnet.io:26657
 secretcli config output json
 secretcli config indent true
 secretcli config trust-node true
@@ -135,7 +135,7 @@ Set up a key. Make sure you backup the mnemonic and the keyring password.
 secretcli keys add $INSERT_YOUR_KEY_NAME
 ```
 
-This will output your address, a 45 character-string starting with `secret1...`. Copy/paste it to get some test-SCRT from [the faucet](https://faucet.pub.testnet.enigma.co/). Continue when you have confirmed your account has some test-SCRT in it.
+This will output your address, a 45 character-string starting with `secret1...`. Copy/paste it to get some test-SCRT from [the faucet](https://faucet.secrettestnet.io/). Continue when you have confirmed your account has some test-SCRT in it.
 
 ### 12. Register your node on-chain
 
@@ -178,10 +178,10 @@ secretd configure-secret node-master-cert.der "$SEED"
 
 ### 16. Add persistent peers to your configuration file.
 
-You can also use Enigma's node:
+You can also use Chain of Secrets' node:
 
 ```bash
-perl -i -pe 's/persistent_peers = ""/persistent_peers = "115aa0a629f5d70dd1d464bc7e42799e00f4edae\@bootstrap.pub.testnet3.enigma.co:26656"/' ~/.secretd/config/config.toml
+perl -i -pe 's/persistent_peers = ""/persistent_peers = "64b03220d97e5dc21ec65bf7ee1d839afb6f7193\@bootstrap.secrettestnet.io:26656"/' ~/.secretd/config/config.toml
 ```
 
 ### 17. Listen for incoming RPC requests so that light nodes can connect to you:
@@ -244,7 +244,7 @@ If someone wants to add you as a peer, have them add the above address to their 
 And if someone wants to use your node from their `secretcli` then have them run:
 
 ```bash
-secretcli config chain-id enigma-pub-testnet-4
+secretcli config chain-id holodeck-2
 secretcli config output json
 secretcli config indent true
 secretcli config node tcp://<your-public-ip>:26657


### PR DESCRIPTION
### Description of the Change

- Added developing-secret-contracts doc
- Updated secretcli version to 1.0.3
- Fixed links
- Updated version numbers for secretnetwork release
- Updated testnet chain ID, bootstrap node and RPC, etc.
- Modified secret-contracts so it matches what's in the dev docs

NOTE: the secret-contracts testnet doc was basically the same as the developing-secret-contracts dev doc. In order to make it more consistent across dev and testnet docs, I updated the testnet docs to match dev.


### Release Notes

N/A