### PR TITLE
Customize attestation_cert.der save path

### DIFF
--- a/cosmwasm/packages/wasmi-runtime/src/consts.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/consts.rs
@@ -46,11 +46,13 @@ pub const SIGNING_METHOD: SigningMethod = SigningMethod::MRSIGNER;
 
 lazy_static! {
     pub static ref CONSENSUS_SEED_SEALING_PATH: String = env::var(SCRT_SGX_STORAGE_ENV_VAR)
-        .unwrap_or_else(|_| "./.sgx_secrets/".to_string())
+        .unwrap_or_else(|_| DEFAULT_SGX_SECRET_PATH.to_string())
         + "consensus_seed.sealed";
     pub static ref REGISTRATION_KEY_SEALING_PATH: String = env::var(SCRT_SGX_STORAGE_ENV_VAR)
-        .unwrap_or_else(|_| "./.sgx_secrets/".to_string())
+        .unwrap_or_else(|_| DEFAULT_SGX_SECRET_PATH.to_string())
         + "new_node_seed_exchange_keypair.sealed";
+    pub static ref ATTESTATION_CERT_PATH: String = env::var(SCRT_SGX_STORAGE_ENV_VAR)
+        .unwrap_or_else(|_| DEFAULT_SGX_SECERT_PATH.to_string())
 }
 
 pub const CONSENSUS_SEED_EXCHANGE_KEYPAIR_DERIVE_ORDER: u32 = 1;
@@ -60,3 +62,5 @@ pub const CONSENSUS_CALLBACK_SECRET_DERIVE_ORDER: u32 = 4;
 
 pub const LOG_LEVEL_ENV_VAR: &str = "LOG_LEVEL";
 pub const SCRT_SGX_STORAGE_ENV_VAR: &str = "SCRT_SGX_STORAGE";
+
+const DEFAULT_SGX_SECRET_PATH: &str = "./.sgx_secrets/";

--- a/cosmwasm/packages/wasmi-runtime/src/registration/offchain.rs
+++ b/cosmwasm/packages/wasmi-runtime/src/registration/offchain.rs
@@ -13,7 +13,7 @@ use enclave_ffi_types::NodeAuthResult;
 
 use crate::consts::{
     ATTESTATION_CERTIFICATE_SAVE_PATH, ENCRYPTED_SEED_SIZE, IO_CERTIFICATE_SAVE_PATH,
-    SEED_EXCH_CERTIFICATE_SAVE_PATH,
+    SEED_EXCH_CERTIFICATE_SAVE_PATH, ATTESTATION_CERT_PATH,
 };
 use crate::crypto::{Keychain, KEY_MANAGER, PUBLIC_KEY_SIZE};
 #[cfg(feature = "SGX_MODE_HW")]
@@ -231,7 +231,8 @@ pub unsafe extern "C" fn ecall_get_attestation_report(
         Ok(res) => res,
     };
 
-    if let Err(status) = write_to_untrusted(cert.as_slice(), ATTESTATION_CERTIFICATE_SAVE_PATH) {
+    let path_prefix = ATTESTATION_CERT_PATH.to_owned();
+    if let Err(status) = write_to_untrusted(cert.as_slice(), path_prefix + ATTESTATION_CERTIFICATE_SAVE_PATH) {
         return status;
     }
 


### PR DESCRIPTION
Based on the #655 ticket I added a new env var resolver and used it in the offchain registration.
_NOTE: I couldn't test it yet, because I trying to setup my environment for that purpose. I created the PR just to see what tests says for that._