### PR TITLE
Make the `signAdapter` return `StdTx` with the new `signDoc` applied

### DIFF
--- a/cosmwasm-js/packages/sdk/types/signingcosmwasmclient.d.ts
+++ b/cosmwasm-js/packages/sdk/types/signingcosmwasmclient.d.ts
@@ -2,7 +2,7 @@ import { Account, CosmWasmClient, GetNonceResult, PostTxResult } from "./cosmwas
 import { SecretUtils } from "./enigmautils";
 import { Log } from "./logs";
 import { BroadcastMode } from "./restclient";
-import { Coin, Msg, StdFee, StdSignature } from "./types";
+import { Coin, Msg, StdFee, StdSignature, StdTx } from "./types";
 import { OfflineSigner } from "./wallet";
 export interface SigningCallback {
   (signBytes: Uint8Array): Promise<StdSignature>;
@@ -76,13 +76,13 @@ export declare class SigningCosmWasmClient extends CosmWasmClient {
   getNonce(address?: string): Promise<GetNonceResult>;
   getAccount(address?: string): Promise<Account | undefined>;
   signAdapter(
-    msgs: readonly Msg[],
+    msgs: Msg[],
     fee: StdFee,
     chainId: string,
     memo: string,
     accountNumber: number,
     sequence: number,
-  ): Promise<StdSignature>;
+  ): Promise<StdTx>;
   /** Uploads code and returns a receipt, including the code ID */
   upload(wasmCode: Uint8Array, meta?: UploadMeta, memo?: string): Promise<UploadResult>;
   instantiate(


### PR DESCRIPTION
#673 
Currently, the `offlineSigner` interface of `cosmjs` returns the new sign doc that is selected by the user. This new sign doc is necessary to allow the users to select the gas and gas price that they want. Therefore, the new sign doc should be applied to the result tx because the signature is specific to the new sign doc.

The actual `signBytes` that the Keplr or other wallet can have different `fee` or `memo` which have been suggested. So, logic should use the returned `StdSignDoc` as well as a signature to make the transaction.

So, to achieve this, I changed the `signAdapter` return not a signature but `StdTx`. If the signer is a legacy interface, it will use the suggested `SignDoc` as it is.