### PR TITLE
Revise links for build.scrt.network/dev

### DIFF
--- a/docs/dev/developing-secret-contracts.md
+++ b/docs/dev/developing-secret-contracts.md
@@ -44,7 +44,7 @@ These IDEs are known to work very well for developing Secret Contracts:
 
 ## Personal Secret Network for Secret Contract development
 
-The developer blockchain is configured to run inside a docker container. Install [Docker](https://docs.docker.com/install/) for your environment (Mac, Windows, Linux).
+The developer blockchain is configured to run inside a docker container. Install [Docker](https://docs.docker.com/get-docker/) for your environment (Mac, Windows, Linux).
 
 Open a terminal window and change to your project directory.
 Then start SecretNetwork, labelled _secretdev_:

--- a/docs/dev/privacy-model-of-secret-contracts.md
+++ b/docs/dev/privacy-model-of-secret-contracts.md
@@ -3,7 +3,7 @@
 Secret Contracts are based on CosmWasm v0.10, but they have additional privacy properties that can only be found on Secret Network.
 
 If you're a contract developer, you might want to first catch up on [developing Secret Contracts](./developing-secret-contracts.md).  
-For an in depth look at the Secret Network encryption specs, visit [here](../protocol/encryption-specs.md).
+For an in depth look at the Secret Network encryption specs, visit [here](../protocol/encryption-specs.md#encryption).
 
 Secret Contract developers must always consider the trade-off between privacy, user experience, performance and gas usage.
 

--- a/docs/dev/privacy-model-of-secret-contracts.md
+++ b/docs/dev/privacy-model-of-secret-contracts.md
@@ -3,7 +3,7 @@
 Secret Contracts are based on CosmWasm v0.10, but they have additional privacy properties that can only be found on Secret Network.
 
 If you're a contract developer, you might want to first catch up on [developing Secret Contracts](./developing-secret-contracts.md).  
-For an in depth look at the Secret Network encryption specs, visit [here](protocol/encryption-specs.md).
+For an in depth look at the Secret Network encryption specs, visit [here](../protocol/encryption-specs.md).
 
 Secret Contract developers must always consider the trade-off between privacy, user experience, performance and gas usage.
 

--- a/docs/dev/privacy-model-of-secret-contracts.md
+++ b/docs/dev/privacy-model-of-secret-contracts.md
@@ -2,7 +2,7 @@
 
 Secret Contracts are based on CosmWasm v0.10, but they have additional privacy properties that can only be found on Secret Network.
 
-If you're a contract developer, you might want to first catch up on [developing Secret Contracts](dev/developing-secret-contracts.md).  
+If you're a contract developer, you might want to first catch up on [developing Secret Contracts](./dev/developing-secret-contracts.md).  
 For an in depth look at the Secret Network encryption specs, visit [here](protocol/encryption-specs.md).
 
 Secret Contract developers must always consider the trade-off between privacy, user experience, performance and gas usage.

--- a/docs/dev/privacy-model-of-secret-contracts.md
+++ b/docs/dev/privacy-model-of-secret-contracts.md
@@ -2,7 +2,7 @@
 
 Secret Contracts are based on CosmWasm v0.10, but they have additional privacy properties that can only be found on Secret Network.
 
-If you're a contract developer, you might want to first catch up on [developing Secret Contracts](./dev/developing-secret-contracts.md).  
+If you're a contract developer, you might want to first catch up on [developing Secret Contracts](./developing-secret-contracts.md).  
 For an in depth look at the Secret Network encryption specs, visit [here](protocol/encryption-specs.md).
 
 Secret Contract developers must always consider the trade-off between privacy, user experience, performance and gas usage.

--- a/docs/dev/secret-contracts.md
+++ b/docs/dev/secret-contracts.md
@@ -51,7 +51,7 @@ apt install build-essential
 
 4. Run cargo install cargo-generate
 
-[Cargo generate](https://doc.rust-lang.org/cargo) is the tool you'll use to create a secret contract project.
+[Cargo generate](https://docs.rs/crate/cargo-generate/) is the tool you'll use to create a secret contract project.
 
 ```
 cargo install cargo-generate --features vendored-openssl


### PR DESCRIPTION
### Description of the Change
Review of all links for build.scrt.network/dev 

### Release Notes
- In secret-contracts.md: Changed link to cargo-generate from referencing cargo book to docs.rs for cargo-generate
- In privacy-model-of-secret-contracts.md: Fix relative link to protocol/encryption-specs.md
- In privacy-model-of-secret-contracts.md: Fix relative link to developing-secret-contracts.md
- In developing-secret-contracts.md: Update docker install link to avoid redirect
