### PR TITLE
Fix ParseEvents to always include wasm.contract_address

### DIFF
--- a/x/compute/internal/types/types.go
+++ b/x/compute/internal/types/types.go
@@ -205,6 +205,7 @@ const AttributeKeyContractAddr = "contract_address"
 func ParseEvents(logs []wasmTypes.LogAttribute, contractAddr sdk.AccAddress) sdk.Events {
 	// we always tag with the contract address issuing this event
 	attrs := []sdk.Attribute{sdk.NewAttribute(AttributeKeyContractAddr, contractAddr.String())}
+	// append attributes from wasm to the sdk.Event
 	for _, l := range logs {
 		// and reserve the contract_address key for our use (not contract)
 		if l.Key != AttributeKeyContractAddr {
@@ -212,6 +213,7 @@ func ParseEvents(logs []wasmTypes.LogAttribute, contractAddr sdk.AccAddress) sdk
 			attrs = append(attrs, attr)
 		}
 	}
+	// each wasm invokation always returns one sdk.Event
 	return sdk.Events{sdk.NewEvent(CustomEventType, attrs...)}
 }
 

--- a/x/compute/internal/types/types.go
+++ b/x/compute/internal/types/types.go
@@ -203,9 +203,6 @@ const AttributeKeyContractAddr = "contract_address"
 
 // ParseEvents converts wasm LogAttributes into an sdk.Events (with 0 or 1 elements)
 func ParseEvents(logs []wasmTypes.LogAttribute, contractAddr sdk.AccAddress) sdk.Events {
-	if len(logs) == 0 {
-		return nil
-	}
 	// we always tag with the contract address issuing this event
 	attrs := []sdk.Attribute{sdk.NewAttribute(AttributeKeyContractAddr, contractAddr.String())}
 	for _, l := range logs {


### PR DESCRIPTION
In `keeper.go`, after every `init` and `execute`, the [`ParseEvents`](https://github.com/CosmWasm/wasmd/blob/b0b407d5f839cfa1c8f0bc7fce06032a3ca5c774/x/wasm/internal/types/types.go#L223) function is called. `if len(logs) == 0` no logs are emitted as a result of this init/exec call, including the log `wasm.contract_address` which should be emitted either way.

As a result, it's impossible to know via websocket `/subscribe` that a contract was called if it was called from another contract and doesn't return logs. (If it's a direct call from a user then there's a `message.contract_address` log).