### PR TITLE
update secret-contract-optimizer rust version to 1.54

### DIFF
--- a/deployment/dockerfiles/secret-contract-optimizer.Dockerfile
+++ b/deployment/dockerfiles/secret-contract-optimizer.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.46
+FROM rust:1.54
 
 RUN rustup target add wasm32-unknown-unknown
 RUN apt update && apt install -y binaryen && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Updates the secret-contract-optimizer to use Rust v 1.54. 

The newer version of Rust prevents `const generics are unstable` error when compiling some third-party libraries. For more on the change see: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#const-generics-mvp