### PR TITLE
Update setup-sgx node doc with newest Intel SGX drivers

### DIFF
--- a/docs/validators-and-full-nodes/setup-sgx.md
+++ b/docs/validators-and-full-nodes/setup-sgx.md
@@ -13,7 +13,7 @@ If you're running a local machine and not a cloud-based VM -
 
 ### Install SGX
 
-Note: `sgx_linux_x64_driver_2.11.0_0373e2e.bin` is the latest driver as of February 24th, 2021. Please check under https://download.01.org/intel-sgx/sgx-linux/ that this is still the case. If not, please send us a PR or notify us.
+Note: `sgx_linux_x64_driver_2.11.0_2d2b795.bin` is the latest driver as of August 24th, 2021. Please check under https://download.01.org/intel-sgx/sgx-linux/ that this is still the case. If not, please send us a PR or notify us.
 
 ```bash
 #! /bin/bash
@@ -24,20 +24,28 @@ PSW_PACKAGES='libsgx-enclave-common libsgx-urts sgx-aesm-service libsgx-uae-serv
 if (($UBUNTUVERSION < 16)); then
 	echo "Your version of Ubuntu is not supported. Must have Ubuntu 16.04 and up. Aborting installation script..."
 	exit 1
-elif (($UBUNTUVERSION < 18)); then
+elif (($UBUNTUVERSION == 16)); then
 	DISTRO='xenial'
 	OS='ubuntu16.04-server'
-else
+elif (($UBUNTUVERSION == 18)); then
 	DISTRO='bionic'
 	OS='ubuntu18.04-server'
+elif (($UBUNTUVERSION == 20)); then
+	DISTRO='focal'
+	OS='ubuntu20.04-server'
 fi
 
 echo "\n\n###############################################"
 echo "#####       Installing Intel SGX driver       #####"
 echo "###############################################\n\n"
 
-# download SGX driver
-wget "https://download.01.org/intel-sgx/sgx-linux/2.13/distro/${OS}/sgx_linux_x64_driver_2.11.0_0373e2e.bin"
+# Download SGX driver
+if (($UBUNTUVERSION == 16)); then
+   # Ubuntu 16 was deprecated by the latest Intel SGX drivers
+   wget "https://download.01.org/intel-sgx/sgx-linux/2.13/distro/${OS}/sgx_linux_x64_driver_2.11.0_0373e2e.bin"
+else
+   wget "https://download.01.org/intel-sgx/sgx-linux/2.14/distro/${OS}/sgx_linux_x64_driver_2.11.0_2d2b795.bin"
+fi
 
 # Make the driver installer executable
 chmod +x ./sgx_linux_x64_driver_*.bin
@@ -78,8 +86,8 @@ if (($UBUNTUVERSION > 18)); then
    sudo apt install -y gdebi
    # Install all the additional necessary dependencies (besides the driver and the SDK)
    # for building a rust enclave
-   wget -O /tmp/libprotobuf10_3.0.0-9_amd64.deb http://ftp.br.debian.org/debian/pool/main/p/protobuf/libprotobuf10_3.0.0-9_amd64.deb
-   yes | sudo gdebi /tmp/libprotobuf10_3.0.0-9_amd64.deb
+   wget -O /tmp/libprotobuf28_3.17.3-2_amd64.deb http://ftp.br.debian.org/debian/pool/main/p/protobuf/libprotobuf28_3.17.3-2_amd64.deb
+   yes | sudo gdebi /tmp/libprotobuf28_3.17.3-2_amd64.deb
 else
    PSW_PACKAGES+=' libprotobuf-dev'
 fi


### PR DESCRIPTION
Updates the setup process with the newest Intel SGX drivers, unless the node is on ubuntu 16.04, in which case Intel is no longer supporting them. 

Tested the install on Ubuntu versions 16/18/20.

Nodefather (I'm not sure of their non-discord handle) said they had to do extra command to get Ubuntu 20 working, but I was unable to replicate. The commands are as follows:

```
sudo apt update
sudo apt install build-essential
sudo apt install sgx-aesm-service libsgx-uae-service libsgx-launch libsgx-urts
```

Signed-off-by: Dylan Schultz <dylanschultz311@gmail.com>